### PR TITLE
Add preventDefault and stopPropagation to avoid blank page

### DIFF
--- a/packages/react/src/components/HelpPanel.tsx
+++ b/packages/react/src/components/HelpPanel.tsx
@@ -19,7 +19,14 @@ export const HelpPanel: React.FC = React.memo(() => {
               {data.info.learnMoreLinks.map(link => {
                 return (
                   <li key={link.text}>
-                    <Link href="#/" onFollow={() => window.electron.openExternalUrl(link.externalUrl)}>
+                    <Link
+                      href="#/"
+                      onFollow={event => {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        window.electron.openExternalUrl(link.externalUrl);
+                      }}
+                    >
                       {link.text}
                     </Link>
                   </li>
@@ -33,7 +40,11 @@ export const HelpPanel: React.FC = React.memo(() => {
             <Link
               href="#/"
               external
-              onFollow={() => window.electron.openExternalUrl(data.info.learnMoreLinks[0].externalUrl)}
+              onFollow={event => {
+                event.preventDefault();
+                event.stopPropagation();
+                window.electron.openExternalUrl(data.info.learnMoreLinks[0].externalUrl);
+              }}
             >
               {data.info.learnMoreLinks[0].text}
             </Link>

--- a/packages/react/src/components/InfoLink.tsx
+++ b/packages/react/src/components/InfoLink.tsx
@@ -17,7 +17,9 @@ export const InfoLink: React.FC<Props> = React.memo(({ heading, mainContent, lea
     <Link
       variant="info"
       href="#/"
-      onFollow={() =>
+      onFollow={event => {
+        event.preventDefault();
+        event.stopPropagation();
         dispatch(
           openTools({
             isOpen: true,
@@ -27,8 +29,8 @@ export const InfoLink: React.FC<Props> = React.memo(({ heading, mainContent, lea
               learnMoreLinks
             }
           })
-        )
-      }
+        );
+      }}
     >
       Info
     </Link>

--- a/packages/react/src/components/MainContent.tsx
+++ b/packages/react/src/components/MainContent.tsx
@@ -181,7 +181,11 @@ const MainContentInternal: React.FC = () => {
                     <li>
                       <LinkComponent
                         href="#/"
-                        onFollow={() => window.electron.openExternalUrl(externalUrls.defaultDocumentation)}
+                        onFollow={event => {
+                          event.preventDefault();
+                          event.stopPropagation();
+                          window.electron.openExternalUrl(externalUrls.defaultDocumentation);
+                        }}
                       >
                         Documentation
                       </LinkComponent>

--- a/packages/react/src/components/PortShared/NugetPackageUpgrades.tsx
+++ b/packages/react/src/components/PortShared/NugetPackageUpgrades.tsx
@@ -239,7 +239,9 @@ const NugetPackageUpgradesInternal: React.FC<Props> = ({ projects, onChange, wat
                 <div>
                   <Link
                     href="#/"
-                    onFollow={() => {
+                    onFollow={event => {
+                      event.preventDefault();
+                      event.stopPropagation();
                       setModalTitle(`${nugetPackage.data.packageVersionPair.packageId} deprecated API calls`);
                       setModalItems(selectedApi.deprecatedApis);
                       setShowModal(true);

--- a/packages/react/src/components/Settings/SettingsDashboard.tsx
+++ b/packages/react/src/components/Settings/SettingsDashboard.tsx
@@ -157,11 +157,25 @@ const SettingsDashboardInternal: React.FC = () => {
               <Box variant="p">
                 The Porting Assistant for .NET tool is licensed as "AWS Content" under the terms and conditions of the
                 AWS Customer Agreement located at{" "}
-                <LinkComponent href="#/" onFollow={() => window.electron.openExternalUrl(externalUrls.agreement)}>
+                <LinkComponent
+                  href="#/"
+                  onFollow={event => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    window.electron.openExternalUrl(externalUrls.agreement);
+                  }}
+                >
                   Agreement
                 </LinkComponent>{" "}
                 and the Service Terms located at{" "}
-                <LinkComponent href="#/" onFollow={() => window.electron.openExternalUrl(externalUrls.serviceTerms)}>
+                <LinkComponent
+                  href="#/"
+                  onFollow={event => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    window.electron.openExternalUrl(externalUrls.serviceTerms);
+                  }}
+                >
                   Service-Terms
                 </LinkComponent>
                 . By installing, using or accessing The Porting Assistant for .NET tool, you agree to such terms and

--- a/packages/react/src/components/Setup/ProfileSelection.tsx
+++ b/packages/react/src/components/Setup/ProfileSelection.tsx
@@ -192,11 +192,13 @@ const ProfileSelecionInternal: React.FC<Props> = ({ title, next, buttonText }) =
                     href="#/"
                     external
                     fontSize="body-s"
-                    onFollow={() =>
+                    onFollow={event => {
+                      event.preventDefault();
+                      event.stopPropagation();
                       window.electron.openExternalUrl(
                         "https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html"
-                      )
-                    }
+                      );
+                    }}
                   >
                     Learn more
                   </Link>
@@ -207,11 +209,15 @@ const ProfileSelecionInternal: React.FC<Props> = ({ title, next, buttonText }) =
                     errorText={errors.profileSelection?.message}
                     constraintText={
                       <Link
-                        href="/#"
+                        href="#/"
                         fontSize="body-s"
                         id="add-named-profile"
                         variant="primary"
-                        onFollow={() => setShowModal(true)}
+                        onFollow={event => {
+                          event.preventDefault();
+                          event.stopPropagation();
+                          setShowModal(true);
+                        }}
                       >
                         Add a named profile
                       </Link>
@@ -229,7 +235,14 @@ const ProfileSelecionInternal: React.FC<Props> = ({ title, next, buttonText }) =
                       empty={
                         <Box variant="small">
                           You have no profiles.{" "}
-                          <Link href="#/" onFollow={() => setShowModal(true)}>
+                          <Link
+                            href="#/"
+                            onFollow={event => {
+                              event.preventDefault();
+                              event.stopPropagation();
+                              setShowModal(true);
+                            }}
+                          >
                             Add a profile
                           </Link>
                         </Box>
@@ -250,7 +263,11 @@ const ProfileSelecionInternal: React.FC<Props> = ({ title, next, buttonText }) =
                     external
                     href="#/"
                     fontSize="body-s"
-                    onFollow={() => window.electron.openExternalUrl(externalUrls.howItWorks)}
+                    onFollow={event => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      window.electron.openExternalUrl(externalUrls.howItWorks);
+                    }}
                   >
                     Learn more
                   </Link>

--- a/packages/react/src/components/Setup/ProfileSelectionModal.tsx
+++ b/packages/react/src/components/Setup/ProfileSelectionModal.tsx
@@ -64,11 +64,13 @@ const ProfileSelectionModalInternal: React.FC<Props> = ({ onAddProfile, onSetMod
               external
               fontSize="body-m"
               href="#/"
-              onFollow={() =>
+              onFollow={event => {
+                event.preventDefault();
+                event.stopPropagation();
                 window.electron.openExternalUrl(
                   "https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html#cli-quick-configuration"
-                )
-              }
+                );
+              }}
             >
               Learn more
             </Link>


### PR DESCRIPTION
*Issue #8 , if available:*
When open the external link, the UI may jump into blank page
*Description of changes:*
Add preventDefault and stopPropagation method
*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including READMEs and comments (where appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific environment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.