### PR TITLE
fix: pop the setting page when configuration is netstandard2.1

### DIFF
--- a/packages/react/src/components/Setup/ProfileSelection.tsx
+++ b/packages/react/src/components/Setup/ProfileSelection.tsx
@@ -44,10 +44,13 @@ const ProfileSelecionInternal: React.FC<Props> = ({ title, next, buttonText }) =
   const dispatch = useDispatch();
   const currentProfile = window.electron.getState("profile");
   const cachedTargetFramework = window.electron.getState("targetFramework");
-  const currentTargetFramework = {
-    label: cachedTargetFramework.label,
-    value: cachedTargetFramework.id
-  };
+  const currentTargetFramework =
+    cachedTargetFramework.id === "netstandard2.1"
+      ? {}
+      : {
+          label: cachedTargetFramework.label,
+          value: cachedTargetFramework.id
+        };
 
   const [targetFramework, setTargetFramework] = useState(currentTargetFramework);
   const [profiles, setProfiles] = useState({ label: currentProfile, id: "" } as SelectProps.Option);

--- a/packages/react/src/createReduxStore.ts
+++ b/packages/react/src/createReduxStore.ts
@@ -87,11 +87,17 @@ const getStateFromCache = (): Partial<RS> => {
   const profile = window.electron.getState("profile");
   const share = window.electron.getState("share");
   const lastConfirmVersion = window.electron.getState("lastConfirmVersion");
+  const targetFramework = window.electron.getState("targetFramework");
   return {
     solution: {
       apiAnalysis: Object.assign({} as SolutionToApiAnalysis, apiAnalysis),
       solutionToSolutionDetails: Object.assign({} as SolutionToSolutionDetails, filteredSolutionToSolutionDetails),
-      profileSet: profile != null && profile.length > 0 && share === true && lastConfirmVersion === "1.3.0"
+      profileSet:
+        profile != null &&
+        profile.length > 0 &&
+        share === true &&
+        lastConfirmVersion === "1.3.0" &&
+        targetFramework.id !== "netstandard2.1"
     },
     nugetPackage: Object.assign(
       {


### PR DESCRIPTION
*Issue #, if available:*
#20 
*Description of changes:*
Pop up setting page if customer's configuration is netstandard2.1
*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including READMEs and comments (where appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific environment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.