### PR TITLE
fix: log link using incorrect date

### DIFF
--- a/packages/electron/src/preload.ts
+++ b/packages/electron/src/preload.ts
@@ -94,7 +94,7 @@ contextBridge.exposeInMainWorld("electron", {
   getVersion: () => invokeBackend("getVersion"),
   telemetry: (message: any) => invokeBackend("telemetry", message),
   getAssessmentLog: () => {
-    const dateString = new Date().toISOString().slice(0,10).replace(/-/g,"");
+    const dateString = new Date().toLocaleDateString("en-CA").slice(0,10).replace(/-/g,"");
     return path.join(remote.app.getPath("userData"), "logs", `portingAssistant-assessment-${dateString}.log`);
   },
   checkInternetAccess: async () => {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
fix get log path function using utc time instead of local time

*Testing done:*
tested local, updated time zone to be +1 days and verified fix properly identified the local time zone when trying to find log.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including READMEs and comments (where appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific environment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.