### PR TITLE
fix: remove electron internet check

### DIFF
--- a/packages/csharp/PortingAssistant/PortingAssistant.Api/Application.cs
+++ b/packages/csharp/PortingAssistant/PortingAssistant.Api/Application.cs
@@ -116,9 +116,12 @@ namespace PortingAssistant.Api
                 var httpService = _services.GetRequiredService<IHttpService>();
                 try
                 {
-                    using var file1 = httpService.DownloadS3FileAsync("newtonsoft.json.json.gz").Result;
-                    using var file2 = httpService.DownloadS3FileAsync("52projects.json.gz").Result;
-                    using var file3 = httpService.DownloadS3FileAsync("2a486f72.mega.json.gz").Result;
+                    var file1 = httpService.DownloadS3FileAsync("newtonsoft.json.json.gz");
+                    file1.Wait();
+                    var file2 = httpService.DownloadS3FileAsync("52projects.json.gz");
+                    file2.Wait();
+                    var file3 = httpService.DownloadS3FileAsync("2a486f72.mega.json.gz");
+                    file3.Wait();
                     return true;
                 }
                 catch

--- a/packages/csharp/PortingAssistant/PortingAssistant.Api/Application.cs
+++ b/packages/csharp/PortingAssistant/PortingAssistant.Api/Application.cs
@@ -9,6 +9,7 @@ using PortingAssistant.VisualStudio;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using PortingAssistant.Client.NuGet.Interfaces;
 
 namespace PortingAssistant.Api
 {
@@ -107,6 +108,22 @@ namespace PortingAssistant.Api
                         Status = Response<bool, string>.Failed(ex),
                         ErrorValue = ex.Message
                     };
+                }
+            });
+
+            _connection.On<string, bool>("checkInternetAccess", request =>
+            {
+                var httpService = _services.GetRequiredService<IHttpService>();
+                try
+                {
+                    using var file1 = httpService.DownloadS3FileAsync("newtonsoft.json.json.gz").Result;
+                    using var file2 = httpService.DownloadS3FileAsync("52projects.json.gz").Result;
+                    using var file3 = httpService.DownloadS3FileAsync("2a486f72.mega.json.gz").Result;
+                    return true;
+                }
+                catch
+                {
+                    return false;
                 }
             });
         }

--- a/packages/electron/src/electron-backend.ts
+++ b/packages/electron/src/electron-backend.ts
@@ -232,6 +232,11 @@ export const initConnection = (logger: any = console) => {
       return response;
     });
 
+    ipcMain.handle("checkInternetAccess", async (_event) => {
+      const response = await connection.send("checkInternetAccess", "");
+      return response;
+    });  
+
     connection.on("onNugetPackageUpdate", (response) => {
       browserWindow.webContents.send("onNugetPackageUpdate", response);
     });

--- a/packages/electron/src/preload.ts
+++ b/packages/electron/src/preload.ts
@@ -97,33 +97,6 @@ contextBridge.exposeInMainWorld("electron", {
     const dateString = new Date().toLocaleDateString("en-CA").slice(0,10).replace(/-/g,"");
     return path.join(remote.app.getPath("userData"), "logs", `portingAssistant-assessment-${dateString}.log`);
   },
-  checkInternetAccess: async () => {
-    const configFile = isDev
-      ? path.join(
-          __dirname,
-          "..",
-          "build-scripts",
-          "porting-assistant-config.dev.json"
-        )
-      : path.join(
-          path.dirname(remote.app.getPath("exe")),
-          "resources",
-          "config",
-          "porting-assistant-config.json"
-        );
-    const config = require(configFile);
-    const s3BaseUrl =
-      config.PortingAssistantConfiguration.DataStoreSettings.HttpsEndpoint;
-    try {
-      const file1 = axios.get(`${s3BaseUrl}newtonsoft.json.json.gz`);
-      const file2 = axios.get(`${s3BaseUrl}52projects.json.gz`);
-      const file3 = axios.get(`${s3BaseUrl}2a486f72.mega.json.gz`);
-      await Promise.any([file1, file2, file3]);
-      return true;
-    } catch {
-      return false;
-    }
-  },
 });
 
 contextBridge.exposeInMainWorld("backend", {
@@ -148,6 +121,7 @@ contextBridge.exposeInMainWorld("backend", {
     listenBackend("onNugetPackageUpdate", callback),
   listenApiAnalysisUpdate: (callback: (message: string) => void) =>
     listenBackend("onApiAnalysisUpdate", callback),
+  checkInternetAccess: () => invokeBackend("checkInternetAccess"),
 });
 
 contextBridge.exposeInMainWorld("porting", {

--- a/packages/react/src/App.tsx
+++ b/packages/react/src/App.tsx
@@ -23,7 +23,6 @@ import { Setup } from "./containers/Setup";
 import { usePortingAssistantSelector } from "./createReduxStore";
 import { init } from "./store/actions/backend";
 import { setCurrentMessageUpdate, setErrorUpdate } from "./store/actions/error";
-import { checkInternetAccess } from "./utils/checkInternetAccess";
 
 interface RouteWithErrorProps extends RouteProps {
   requireProfile: boolean;
@@ -80,7 +79,6 @@ const AppInternal: React.FC<{}> = () => {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    checkInternetAccess("", dispatch);
     const hasProfile = window.electron.getState("profile");
     if (hasProfile) {
       dispatch(init(false));

--- a/packages/react/src/__tests__/selectors.test.ts
+++ b/packages/react/src/__tests__/selectors.test.ts
@@ -950,9 +950,6 @@ describe("selectDashboardTableData", () => {
 });
 
 describe("checkInternetAccess", () => {
-  window.electron.checkInternetAccess = jest.fn();
-  jest.spyOn(window.electron, "checkInternetAccess").mockReturnValue(Promise.resolve(false));
-
   it("should add internet access error to messages", async () => {
     const result = await checkInternetAccess("", dispatch);
     expect(result).toBe(false);

--- a/packages/react/src/bootstrapElectron.ts
+++ b/packages/react/src/bootstrapElectron.ts
@@ -65,6 +65,7 @@ export interface Backend {
   listenApiAnalysisUpdate: (
     callback: (projectAnalysis: Response<ProjectApiAnalysisResult, SolutionProject>) => void
   ) => void;
+  checkInternetAccess: () => Promise<boolean>;
 }
 
 export interface Porting {

--- a/packages/react/src/setupTests.ts
+++ b/packages/react/src/setupTests.ts
@@ -39,5 +39,8 @@ global.window = {
       throw new Error("not implement");
     },
     dialog: {} as any
+  },
+  backend: {
+    checkInternetAccess: () => false
   }
 } as any;

--- a/packages/react/src/store/sagas/backendSaga.ts
+++ b/packages/react/src/store/sagas/backendSaga.ts
@@ -93,7 +93,7 @@ export function* watchApiAnalysisUpdate() {
 
 function* handleInit(action: ReturnType<typeof init>) {
   yield put(ping());
-  const haveInternet: boolean = yield window.electron.checkInternetAccess();
+  const haveInternet: boolean = yield window.backend.checkInternetAccess();
   const storedSolutions = window.electron.getState("solutions", {});
   const targetFramework = getTargetFramework();
   if (!haveInternet) {

--- a/packages/react/src/utils/checkInternetAccess.ts
+++ b/packages/react/src/utils/checkInternetAccess.ts
@@ -5,7 +5,7 @@ import { analyzeSolution } from "../store/actions/backend";
 import { setCurrentMessageUpdate } from "../store/actions/error";
 
 export const checkInternetAccess = async (solutionPath: string, dispatch: Dispatch) => {
-  const haveInternet: boolean = await window.electron.checkInternetAccess();
+  const haveInternet: boolean = await window.backend.checkInternetAccess();
   if (!haveInternet) {
     dispatch(setCurrentMessageUpdate([internetAccessFailed()]));
     if (solutionPath !== "") {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
revert back to c# internet access check because electron version would cache result

*Testing done:*
manually tested
no internet -> internet -> no internet, all returned expected results.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including READMEs and comments (where appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific environment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.