### PR TITLE
change: remove opensource cli from PA installer

### DIFF
--- a/packages/electron/build-scripts/install-csharp.bat
+++ b/packages/electron/build-scripts/install-csharp.bat
@@ -2,6 +2,3 @@ rmdir /s/q netcore_build
 mkdir netcore_build
 dotnet publish ..\csharp\PortingAssistant\PortingAssistant.Api\PortingAssistant.Api.csproj -c Release -f netcoreapp3.1 -o netcore_build
 dotnet publish ..\csharp\PortingAssistant\PortingAssistant.Telemetry\PortingAssistant.Telemetry.csproj -c Release -f netcoreapp3.1 -o netcore_build 
-for /F delims^=^"^ tokens^=4 %%G in ('findstr "PortingAssistant.Client.Client"  ..\csharp\PortingAssistant\PortingAssistant.Api\PortingAssistant.Api.csproj') do @set "version=%%G"
-set cliDownloadLink="https://s3.us-west-2.amazonaws.com/aws.portingassistant.dotnet.download/nuget/flatcontainer/portingassistant.client.cli/%version%/PortingAssistant.Client.CLI.exe"
-curl %cliDownloadLink% --output netcore_build/PortingAssistant.Client.CLI.exe

--- a/packages/electron/build-scripts/install-csharp.sh
+++ b/packages/electron/build-scripts/install-csharp.sh
@@ -3,6 +3,3 @@ rm -rf ./netcore_build/
 mkdir ./netcore_build/
 (dotnet publish ../csharp/PortingAssistant/PortingAssistant.Api/PortingAssistant.Api.csproj -c Release -f netcoreapp3.1 -o ./netcore_build/)
 (dotnet publish ../csharp/PortingAssistant/PortingAssistant.Telemetry/PortingAssistant.Telemetry.csproj -c Release -f netcoreapp3.1 -o ./netcore_build/)
-version=$(grep 'PortingAssistant.Client.Client' ../csharp/PortingAssistant/PortingAssistant.Api/PortingAssistant.Api.csproj | sed 's/.*Version="\(.*\)".*/\1/')
-cliDownloadLink="https://s3.us-west-2.amazonaws.com/aws.portingassistant.dotnet.download/nuget/flatcontainer/portingassistant.client.cli/${version}/PortingAssistant.Client.CLI.exe"
-curl $cliDownloadLink -o ./netcore_build/PortingAssistant.Client.CLI.exe


### PR DESCRIPTION
We want to wait till after PA release for Optimus integration to include the opensource CLI for Drift.

*Testing done:*
Manual test by building the PA installer manually.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md#commit-your-change)
- [X] I have updated any necessary documentation, including READMEs and comments (where appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have checked that my tests are not configured for a specific environment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.