### PR TITLE
feat: Download and package PortingAssistant.Client.CLI.exe in standal…

### DIFF
--- a/packages/electron/build-scripts/install-csharp.bat
+++ b/packages/electron/build-scripts/install-csharp.bat
@@ -2,3 +2,6 @@ rmdir /s/q netcore_build
 mkdir netcore_build
 dotnet publish ..\csharp\PortingAssistant\PortingAssistant.Api\PortingAssistant.Api.csproj -c Release -f netcoreapp3.1 -o netcore_build
 dotnet publish ..\csharp\PortingAssistant\PortingAssistant.Telemetry\PortingAssistant.Telemetry.csproj -c Release -f netcoreapp3.1 -o netcore_build 
+for /F delims^=^"^ tokens^=4 %%G in ('findstr "PortingAssistant.Client.Client"  ..\csharp\PortingAssistant\PortingAssistant.Api\PortingAssistant.Api.csproj') do @set "version=%%G"
+set cliDownloadLink="https://s3.us-west-2.amazonaws.com/aws.portingassistant.dotnet.download/nuget/flatcontainer/portingassistant.client.cli/%version%/PortingAssistant.Client.CLI.exe"
+curl %cliDownloadLink% --output netcore_build/PortingAssistant.Client.CLI.exe

--- a/packages/electron/build-scripts/install-csharp.sh
+++ b/packages/electron/build-scripts/install-csharp.sh
@@ -3,3 +3,6 @@ rm -rf ./netcore_build/
 mkdir ./netcore_build/
 (dotnet publish ../csharp/PortingAssistant/PortingAssistant.Api/PortingAssistant.Api.csproj -c Release -f netcoreapp3.1 -o ./netcore_build/)
 (dotnet publish ../csharp/PortingAssistant/PortingAssistant.Telemetry/PortingAssistant.Telemetry.csproj -c Release -f netcoreapp3.1 -o ./netcore_build/)
+version=$(grep 'PortingAssistant.Client.Client' ../csharp/PortingAssistant/PortingAssistant.Api/PortingAssistant.Api.csproj | sed 's/.*Version="\(.*\)".*/\1/')
+cliDownloadLink="https://s3.us-west-2.amazonaws.com/aws.portingassistant.dotnet.download/nuget/flatcontainer/portingassistant.client.cli/${version}/PortingAssistant.Client.CLI.exe"
+curl $cliDownloadLink -o ./netcore_build/PortingAssistant.Client.CLI.exe


### PR DESCRIPTION
…one tool.

*Issue #, if available:*

*Description of changes:*
`porting-assistant-dotnet-client` github workflow [publishes and uploads](https://github.com/aws/porting-assistant-dotnet-client/pull/150) `PortingAssistant.Client.CLI.exe` to a public S3 bucket. This patch downloads `PortingAssistant.Client.CLI.exe` from that S3 bucket and packages it in Porting Assistant standalone tool executable.

*Testing done:*
Manually tested it by running npm run build on the following two systems:
1. MacOS Catalina
2. Windows 10 64bit
And verify PortingAssistant.Client.CLI.exe exists under porting-assistant-dotnet-ui/packages/electron/netcore_build directory.


## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including READMEs and comments (where appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific environment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.