### PR TITLE
change:update PortingAssistant.Client.Client nuget pacakge version.

### DIFF
--- a/packages/csharp/PortingAssistant/PortingAssistant.Api/PortingAssistant.Api.csproj
+++ b/packages/csharp/PortingAssistant/PortingAssistant.Api/PortingAssistant.Api.csproj
@@ -9,7 +9,7 @@
 		<PackageReference Include="ElectronCgi.DotNet" Version="1.0.3" />
 		<PackageReference Include="Serilog.Sinks.RollingFile" Version="3.3.0" />
 		<PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />
-    <PackageReference Include="PortingAssistant.Client.Client" Version="1.8.58-g4467f9eb56" />
+		<PackageReference Include="PortingAssistant.Client.Client" Version="1.8.63-gcdd4e65982" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\PortingAssistant.Common\PortingAssistant.Common.csproj" />

--- a/packages/csharp/PortingAssistant/PortingAssistant.Common/PortingAssistant.Common.csproj
+++ b/packages/csharp/PortingAssistant/PortingAssistant.Common/PortingAssistant.Common.csproj
@@ -15,7 +15,7 @@
     <Folder Include="Listener\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="PortingAssistant.Client.Client" Version="1.8.58-g4467f9eb56" />
+    <PackageReference Include="PortingAssistant.Client.Client" Version="1.8.63-gcdd4e65982" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.8" />
     <PackageReference Include="System.Web.Helpers.Crypto" Version="3.2.3" />

--- a/packages/csharp/PortingAssistant/PortingAssistant.Telemetry/PortingAssistant.Telemetry.csproj
+++ b/packages/csharp/PortingAssistant/PortingAssistant.Telemetry/PortingAssistant.Telemetry.csproj
@@ -9,9 +9,9 @@
     <PackageReference Include="Aws4RequestSigner" Version="1.0.3" />
     <PackageReference Include="ElectronCgi.DotNet" Version="1.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.8" />
-    <PackageReference Include="PortingAssistant.Client.Client" Version="1.8.58-g4467f9eb56" />
+    <PackageReference Include="PortingAssistant.Client.Client" Version="1.8.63-gcdd4e65982" />
     <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
     <PackageReference Include="System.Web.Helpers.Crypto" Version="3.2.3" />
-    <PackageReference Include="PortingAssistant.Client.Telemetry" Version="1.8.41-g07201d3178" />
+    <PackageReference Include="PortingAssistant.Client.Telemetry" Version="1.8.63-gcdd4e65982" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Update version to ensure the client version is consistent with the version that PortingAssistantCLI.exe depends on. This is to make sure PA standalone tool pipeline is able to find and download the right version of  PortingAssistantCLI.exe.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including READMEs and comments (where appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific environment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.