### PR TITLE
fix: use sdk for request signing

### DIFF
--- a/packages/electron/package-lock.json
+++ b/packages/electron/package-lock.json
@@ -10,6 +10,224 @@
       "integrity": "sha512-GLyWIFBbGvpKPGo55JyRZAo4lVbnBiD52cKlw/0Vt+wnmKvWJkpZvsjVoaIolyBXDeAQKSicRtqFNPem9w0WYA==",
       "dev": true
     },
+    "@aws-crypto/ie11-detection": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
+      "integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
+      "requires": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "@aws-crypto/sha256-browser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.1.tgz",
+      "integrity": "sha512-P4Af7E2iJqZN2HYMdWINEg++OC2CtP1ygTx6WQCzZISQA+i3Q+K3E8S8t/PSYqUnvtfh5XVjbFT9uA+4IT8C2w==",
+      "requires": {
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/sha256-js": "^2.0.1",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-crypto/util": "^2.0.1",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "@aws-crypto/sha256-js": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.1.tgz",
+      "integrity": "sha512-mbHTBSPBvg6o/mN/c18Z/zifM05eJrapj5ggoOIeHIWckvkv5VgGi7r/wYpt+QAO2ySKXLNvH2d8L7bne4xrMQ==",
+      "requires": {
+        "@aws-crypto/util": "^2.0.1",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "@aws-crypto/supports-web-crypto": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.0.tgz",
+      "integrity": "sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==",
+      "requires": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "@aws-crypto/util": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.1.tgz",
+      "integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
+      "requires": {
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "@aws-sdk/abort-controller": {
+      "version": "3.47.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.47.1.tgz",
+      "integrity": "sha512-S6dBqd9Lc4kZSSLqBDNWAgDAkqdqhSFe9yKTUGYtY0Ih9u+9vrE761ENQZr14IdmGjuwp7V31IuepCwvE0xw+A==",
+      "requires": {
+        "@aws-sdk/types": "3.47.1",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/is-array-buffer": {
+      "version": "3.47.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.47.1.tgz",
+      "integrity": "sha512-HQMvT3dP6DCjmn87WkzYxUF9RqkvuXgKfddLEKj/tg/OgDQJv9xIPjEEry8Fd36ncbBqaBmC/z2ETZhpzHQvXA==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/node-http-handler": {
+      "version": "3.47.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.47.1.tgz",
+      "integrity": "sha512-m6TtTD4nRP18qbnHipEFIUWOahwusrByTLWtg2m2AbAQ8POEz+LVpoxBOO5TZGAxnLrqOcoXHkF+2YbwfPTJUw==",
+      "requires": {
+        "@aws-sdk/abort-controller": "3.47.1",
+        "@aws-sdk/protocol-http": "3.47.1",
+        "@aws-sdk/querystring-builder": "3.47.1",
+        "@aws-sdk/types": "3.47.1",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/protocol-http": {
+      "version": "3.47.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.47.1.tgz",
+      "integrity": "sha512-4yzedIJOFLEQacwS70IKIZ5+4qdBQXPS//+56/PK3RzOrPkyW+cGRRGlBPPH7UYg4NifBcEZI0VorjrzA7mYgw==",
+      "requires": {
+        "@aws-sdk/types": "3.47.1",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/querystring-builder": {
+      "version": "3.47.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.47.1.tgz",
+      "integrity": "sha512-he1NKIAh9hKpzBPahnZ90HIQNXQdJzkdddqijfTrCbyo+r0WA6VQ0R+WUP71CUceU6NMEs8DspSjSUfppvDouA==",
+      "requires": {
+        "@aws-sdk/types": "3.47.1",
+        "@aws-sdk/util-uri-escape": "3.47.1",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/signature-v4": {
+      "version": "3.47.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.47.1.tgz",
+      "integrity": "sha512-GxynXbnzGW69+0WAbzFhHSr/lDHntB7GM5m8Q1bqa/KsxrnTbhrasERPnnfSUrukrUzcPsAGvcpvNwQ04lPQbw==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.47.1",
+        "@aws-sdk/types": "3.47.1",
+        "@aws-sdk/util-hex-encoding": "3.47.1",
+        "@aws-sdk/util-uri-escape": "3.47.1",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/types": {
+      "version": "3.47.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.47.1.tgz",
+      "integrity": "sha512-c+lxJJLD5Bq8HkrgaIWQfK8oGH53CYpRRJizyQ5qfRo9aXp/qshUnIVcgnA8t0k7jfzcIfa0Q7jSSBw3EerEbg=="
+    },
+    "@aws-sdk/util-hex-encoding": {
+      "version": "3.47.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.47.1.tgz",
+      "integrity": "sha512-9vBhp1E74s6nImK5xk7BkopQ10w6Vk8UrIinu71U7V/0PdjCEb4Jmnn++MLyim2jTT0QEGmJ6v0VjPZi9ETWaA==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/util-locate-window": {
+      "version": "3.47.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.47.1.tgz",
+      "integrity": "sha512-dMcBhtyJ7ZMNS8RS4UOVbkiR0gGrBWv+p1s9NLfMNXod9zaTAlMIKl9de8Xdshguvc8//J7heQV/7+HMvFEq2g==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/util-uri-escape": {
+      "version": "3.47.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.47.1.tgz",
+      "integrity": "sha512-CGqm+bT07OCJSgDo48/4Fegh9tNPR3kcOMfNWZ/J6lrt+nfAnOdXx5zZB63PjKCt5zJ7LM0thOQgAeOf2WdJzQ==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/util-utf8-browser": {
+      "version": "3.47.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.47.1.tgz",
+      "integrity": "sha512-PzHEdiBhfnZbHvZ+dIlIPodDbpgrpKDYslHe9A+tH8ZfuAxxmZEqnukp7QEkFr6mBcmq3H2thcPdNT45/5pA7Q==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
@@ -77,14 +295,6 @@
             "has-flag": "^3.0.0"
           }
         }
-      }
-    },
-    "@babel/runtime": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.1.tgz",
-      "integrity": "sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==",
-      "requires": {
-        "regenerator-runtime": "^0.13.4"
       }
     },
     "@dabh/diagnostics": {
@@ -473,29 +683,6 @@
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
-    "aws-api-gateway-client": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/aws-api-gateway-client/-/aws-api-gateway-client-0.3.5.tgz",
-      "integrity": "sha512-vKpwgP9yL8fzZ3Svh4O6IVieVAzYWqh89jz5w1qGNO/BFGvBEasn6bOpejhFFsSV/6E1JmghRdIYN1CcKz5eTw==",
-      "requires": {
-        "@babel/runtime": "^7.9.6",
-        "axios": "^0.19.2",
-        "axios-retry": "^3.1.8",
-        "crypto-js": "^4.0.0",
-        "url": "^0.11.0",
-        "url-template": "^2.0.8"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "0.19.2",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-          "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-          "requires": {
-            "follow-redirects": "1.5.10"
-          }
-        }
-      }
-    },
     "aws-sdk": {
       "version": "2.778.0",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.778.0.tgz",
@@ -547,14 +734,6 @@
       "requires": {
         "follow-redirects": "1.5.10",
         "is-buffer": "^2.0.2"
-      }
-    },
-    "axios-retry": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.1.9.tgz",
-      "integrity": "sha512-NFCoNIHq8lYkJa6ku4m+V1837TP6lCa7n79Iuf8/AqATAHYB0ISaAS1eyIenDOfHOLtym34W65Sjke2xjg2fsA==",
-      "requires": {
-        "is-retry-allowed": "^1.1.0"
       }
     },
     "balanced-match": {
@@ -1023,11 +1202,6 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
-    },
-    "crypto-js": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.0.0.tgz",
-      "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg=="
     },
     "crypto-random-string": {
       "version": "2.0.0",
@@ -1916,11 +2090,6 @@
       "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
       "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
     },
-    "is-retry-allowed": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
-    },
     "is-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
@@ -2798,11 +2967,6 @@
         "util-deprecate": "~1.0.1"
       }
     },
-    "regenerator-runtime": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-    },
     "registry-auth-token": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.0.tgz",
@@ -3486,15 +3650,6 @@
         }
       }
     },
-    "url": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-      "requires": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      }
-    },
     "url-parse-lax": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
@@ -3503,11 +3658,6 @@
       "requires": {
         "prepend-http": "^2.0.0"
       }
-    },
-    "url-template": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
-      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE="
     },
     "utf8-byte-length": {
       "version": "1.0.4",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -49,7 +49,6 @@
   },
   "dependencies": {
     "@porting-assistant/react": "^1.6.4",
-    "aws-api-gateway-client": "^0.3.5",
     "aws-sdk": "^2.570.0",
     "axios": "^0.18.0",
     "electron-cgi": "^1.0.6",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -48,6 +48,11 @@
     "yargs": "^14.2.0"
   },
   "dependencies": {
+    "@aws-crypto/sha256-browser": "^2.0.1",
+    "@aws-sdk/node-http-handler": "^3.47.1",
+    "@aws-sdk/protocol-http": "^3.47.1",
+    "@aws-sdk/signature-v4": "^3.47.1",
+    "@aws-sdk/types": "^3.47.1",
     "@porting-assistant/react": "^1.6.4",
     "aws-sdk": "^2.570.0",
     "axios": "^0.18.0",

--- a/packages/electron/src/telemetry/electron-metrics.ts
+++ b/packages/electron/src/telemetry/electron-metrics.ts
@@ -1,83 +1,65 @@
 import path from "path";
 import { app } from "electron";
 import electronIsDev from "electron-is-dev";
-import apigClientFactory from "aws-api-gateway-client";
 import { getProfileCredentials } from "./electron-get-profile-credentials";
 import { PutLogDataRequest } from "../models/putLogDataRequest";
 import { PutMetricDataRequest } from "../models/putMetricDataRequest";
 import { localStore } from "../preload-localStore";
+import { Credentials } from "@aws-sdk/types";
+import { SignatureV4 } from "@aws-sdk/signature-v4";
+import { HttpRequest, HttpResponse } from "@aws-sdk/protocol-http";
+import { Sha256 } from "@aws-crypto/sha256-browser";
+import { NodeHttpHandler } from "@aws-sdk/node-http-handler";
 
 // Configuraion
 export const config = require(electronIsDev
-  ? path.join(
-      __dirname,
-      "../..",
-      "build-scripts",
-      "porting-assistant-config.dev.json"
-    )
-  : path.join(
-      path.dirname(app.getPath("exe")),
-      "resources",
-      "config",
-      "porting-assistant-config.json"
-    ));
+  ? path.join(__dirname, "../..", "build-scripts", "porting-assistant-config.dev.json")
+  : path.join(path.dirname(app.getPath("exe")), "resources", "config", "porting-assistant-config.json"));
 
-// Create client
-const createClient = (
-  profileName: string,
-  region: string,
-  invokeUrl: string
-) => {
-  let credentials:
-    | AWS.SharedIniFileCredentials
-    | undefined = getProfileCredentials(profileName);
-  const awsAccessKeyId: string | undefined = credentials?.accessKeyId;
-  const awsSecretAccessKey: string | undefined = credentials?.secretAccessKey;
-  const awsSessionToken: string | undefined = credentials?.sessionToken;
-
-  if (awsAccessKeyId === undefined || awsSecretAccessKey === undefined) {
-    console.error(`Credentials are undefined for profile: ${profileName}`);
-    return null;
-  }
-  const apigClient = apigClientFactory.newClient({
-    invokeUrl: invokeUrl,
-    region: region,
-    accessKey: awsAccessKeyId,
-    secretKey: awsSecretAccessKey,
-    sessionToken: awsSessionToken,
-  });
-  return apigClient;
-};
-
-const createRequest = async (
+const sendRequest = async (
   pathParams: { [key: string]: string },
   pathTemplate: string,
   method: string,
   additionalParams: { [key: string]: string },
-  body: PutLogDataRequest | PutMetricDataRequest
+  body: PutLogDataRequest | PutMetricDataRequest,
+  newProfile?: string | undefined
 ): Promise<boolean> => {
-  var apigClient = createClient(
-    localStore.get("profile"),
-    config.PortingAssistantMetrics.Region,
-    config.PortingAssistantMetrics.InvokeUrl
-  );
-  var metricsEnabled = localStore.get("share");
-  if (metricsEnabled && apigClient != null) {
-    try {
-      await apigClient.invokeApi(
-        pathParams,
-        pathTemplate,
-        method,
-        additionalParams,
-        body
-      );
-      return true;
-    } catch (e) {
-      console.error(e);
-      return false;
-    }
-  } else {
+  const metricsEnabled = localStore.get("share");
+  const profileName = newProfile || localStore.get("profile");
+  const credentials: AWS.SharedIniFileCredentials | undefined = getProfileCredentials(profileName);
+
+  if (!metricsEnabled) {
     return true;
+  }
+  if (credentials?.accessKeyId === undefined || credentials?.secretAccessKey === undefined) {
+    console.error(`Credentials are undefined for profile: ${profileName}`);
+    return false;
+  }
+
+  try {
+    var signedRequest = await createAndSignRequest(body, pathTemplate, method, credentials);
+    var client = new NodeHttpHandler();
+    var { response } = await client.handle(signedRequest as HttpRequest);
+    logResponse(response);
+    return response.statusCode < 300;
+  } catch (e) {
+    console.error(e);
+    return false;
+  }
+};
+
+const logResponse = async (response: HttpResponse) => {
+  var responseBody = "";
+  console.log(response.statusCode + " " + response.body.statusMessage);
+  try {
+    response.body.on("data", (chunk: string) => {
+      responseBody += chunk;
+    });
+    response.body.on("end", () => {
+      console.log("Response body: " + responseBody);
+    });
+  } catch (e) {
+    console.log(e);
   }
 };
 
@@ -100,13 +82,7 @@ export const putLogData = async (logName: string, logData: string) => {
       logData: logData,
     },
   };
-  return await createRequest(
-    pathParams,
-    pathTemplate,
-    method,
-    additionalParams,
-    body
-  );
+  return await sendRequest(pathParams, pathTemplate, method, additionalParams, body);
 };
 
 // Create putMetricData request
@@ -140,56 +116,55 @@ export const putMetricData = async (
       },
     ],
   };
-  return await createRequest(
-    pathParams,
-    pathTemplate,
-    method,
-    additionalParams,
-    body
-  );
+  return await sendRequest(pathParams, pathTemplate, method, additionalParams, body);
 };
 
 export const testProfile = async (profile: string) => {
-  var apigClient = createClient(
-    profile,
-    config.PortingAssistantMetrics.Region,
-    config.PortingAssistantMetrics.InvokeUrl
-  );
-  if (apigClient == null) {
-    return false;
-  }
   try {
-    const response = await apigClient.invokeApi(
-      {},
-      "/put-log-data",
-      "POST",
-      {},
-      {
-        requestMetadata: {
-          version: "1.0",
-          service: config.PortingAssistantMetrics.ServiceName,
-          token: "12345678", // Hard-coded as client side  authentication not implemented yet
-          description: "PortingAssistant Log",
-        },
-        log: {
-          timeStamp: new Date().toLocaleString(),
-          logName: "verify-user",
-          logData: "",
-        },
-      }
-    );
-    if (response.status === 200) {
-      return true;
-    }
-    return false;
+    const body = {
+      requestMetadata: {
+        version: "1.0",
+        service: config.PortingAssistantMetrics.ServiceName,
+        token: "12345678", // Hard-coded as client side  authentication not implemented yet
+        description: "PortingAssistant Log",
+      },
+      log: {
+        timeStamp: new Date().toLocaleString(),
+        logName: "verify-user",
+        logData: "",
+      },
+    };
+    return await sendRequest({}, "/put-log-data", "POST", {}, body, profile);
   } catch (ex) {
     console.error(ex);
     return false;
   }
 };
+async function createAndSignRequest(
+  body: PutLogDataRequest | PutMetricDataRequest,
+  pathTemplate: string,
+  method: string,
+  credentials: Credentials
+) {
+  var request = new HttpRequest({
+    body: JSON.stringify(body),
+    headers: {
+      "Content-Type": "application/json",
+      host: config.PortingAssistantMetrics.InvokeUrl.replace("https://", ""),
+    },
+    hostname: config.PortingAssistantMetrics.InvokeUrl.replace("https://", ""),
+    method: method,
+    path: pathTemplate,
+  });
 
-// // Example Call
-// putLogData("test-log", "test");
-// putMetricData("portingAssistant-backend", "test-metric", "Count", 1, [
-//   { Value: "test", Name: "Test" },
-// ]);
+  // Sign the request
+  var signer = new SignatureV4({
+    credentials: credentials,
+    region: config.PortingAssistantMetrics.Region,
+    service: "execute-api",
+    sha256: Sha256,
+  });
+  var signedRequest = await signer.sign(request);
+  return signedRequest;
+}
+

--- a/packages/electron/src/telemetry/electron-metrics.ts
+++ b/packages/electron/src/telemetry/electron-metrics.ts
@@ -146,13 +146,17 @@ async function createAndSignRequest(
   method: string,
   credentials: Credentials
 ) {
+  var invokeUrl = new URL(config.PortingAssistantMetrics.InvokeUrl);
+  if (invokeUrl.pathname !== "/") {
+    pathTemplate = invokeUrl.pathname + pathTemplate;
+  }
   var request = new HttpRequest({
     body: JSON.stringify(body),
     headers: {
       "Content-Type": "application/json",
-      host: config.PortingAssistantMetrics.InvokeUrl.replace("https://", ""),
+      host: invokeUrl.host,
     },
-    hostname: config.PortingAssistantMetrics.InvokeUrl.replace("https://", ""),
+    hostname: invokeUrl.hostname,
     method: method,
     path: pathTemplate,
   });


### PR DESCRIPTION
*Description of changes:*
Replace npm package https://www.npmjs.com/package/aws-api-gateway-client with aws sdk for signing http requests to metrics endpoint

*Testing done:*
manual testing done:
[x] verify profile check with short term and long term creds
[x] add a new profile
[x] logs uploaded with both short term and long term creds


## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including READMEs and comments (where appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific environment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.