### PR TITLE
fix: Rename Target Framework to Project Framework to reduce confusion

### DIFF
--- a/packages/react/src/components/AssessSolution/ProjectsTable.tsx
+++ b/packages/react/src/components/AssessSolution/ProjectsTable.tsx
@@ -101,7 +101,7 @@ const ProjectsTableInternal: React.FC<Props> = ({ solution }) => {
                     <Box variant="strong">Name</Box> - Name of the project.
                   </Box>
                   <Box variant="p">
-                    <Box variant="strong">Project framework</Box> - Source framework of the project.
+                    <Box variant="strong">Project framework</Box> - Target framework of the project.
                   </Box>
                   <Box variant="p">
                     <Box variant="strong">Referenced projects</Box> - Number of other projects that are referenced by

--- a/packages/react/src/components/AssessSolution/ProjectsTable.tsx
+++ b/packages/react/src/components/AssessSolution/ProjectsTable.tsx
@@ -101,7 +101,7 @@ const ProjectsTableInternal: React.FC<Props> = ({ solution }) => {
                     <Box variant="strong">Name</Box> - Name of the project.
                   </Box>
                   <Box variant="p">
-                    <Box variant="strong">Target framework</Box> - Target framework of the project.
+                    <Box variant="strong">Project framework</Box> - Source framework of the project.
                   </Box>
                   <Box variant="p">
                     <Box variant="strong">Referenced projects</Box> - Number of other projects that are referenced by
@@ -224,9 +224,9 @@ const columnDefinitions: TableProps.ColumnDefinition<TableData>[] = [
   },
   {
     id: "target-framework",
-    header: "Target framework",
+    header: "Project framework",
     cell: item => <div id={`target-framework-${escapeNonAlphaNumeric(item.projectPath)}`}>{item.targetFramework}</div>,
-    sortingField: "targetFramework"
+    sortingField: "projectFramework"
     //minWidth: "200px"
   },
   {

--- a/packages/react/src/components/PortSolution/PortSolutionSummary.tsx
+++ b/packages/react/src/components/PortSolution/PortSolutionSummary.tsx
@@ -29,7 +29,7 @@ const columnDefinitions: TableProps.ColumnDefinition<Project>[] = [
   },
   {
     id: "target-framework",
-    header: "Target framework",
+    header: "Project framework",
     cell: item => item.targetFrameworks?.join(", ") || ""
   }
 ];


### PR DESCRIPTION
*Based on customer feedback that we use Target framework during Port project and Project table view, which is confusing since we are porting from a source framework to a target framework in the process.*

*This change is to rename Target framework to Project framework to reduce confusion during Port Project page and Project table view.*

*Testing done:*
![Screen Shot 2022-02-24 at 7 46 22 PM](https://user-images.githubusercontent.com/34224380/155753546-f4a6296d-dc44-4295-aeeb-3560b78f4589.png)
![Screen Shot 2022-02-24 at 7 46 47 PM](https://user-images.githubusercontent.com/34224380/155753551-27045767-f4a4-4723-8520-d4d5a28b851c.png)


## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including READMEs and comments (where appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific environment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.