### PR TITLE
fix: verify profile when metrics disabled

### DIFF
--- a/packages/electron/src/telemetry/electron-metrics.ts
+++ b/packages/electron/src/telemetry/electron-metrics.ts
@@ -26,18 +26,28 @@ const sendRequest = async (
 ): Promise<boolean> => {
   const metricsEnabled = localStore.get("share");
   const profileName = newProfile || localStore.get("profile");
-  const credentials: AWS.SharedIniFileCredentials | undefined = getProfileCredentials(profileName);
+  const credentials: AWS.SharedIniFileCredentials | undefined =
+    getProfileCredentials(profileName);
 
-  if (!metricsEnabled) {
+  // new profile verification just needs to ping endpoint so bypass flag
+  if (!metricsEnabled && !newProfile) {
     return true;
   }
-  if (credentials?.accessKeyId === undefined || credentials?.secretAccessKey === undefined) {
+  if (
+    credentials?.accessKeyId === undefined ||
+    credentials?.secretAccessKey === undefined
+  ) {
     console.error(`Credentials are undefined for profile: ${profileName}`);
     return false;
   }
 
   try {
-    var signedRequest = await createAndSignRequest(body, pathTemplate, method, credentials);
+    var signedRequest = await createAndSignRequest(
+      body,
+      pathTemplate,
+      method,
+      credentials
+    );
     var client = new NodeHttpHandler();
     var { response } = await client.handle(signedRequest as HttpRequest);
     logResponse(response);


### PR DESCRIPTION
*Description of changes:*
Fix issue where profile verification would return true because metrics option was disabled or not yet set. This was found out in the integration tests.

True result will force return true, False will continue to endpoint which is the normal circumstance.

!metricsEnabled && !newProfile
|   | T | F |
| ------------- | ------------- | ------------- |
| T | metrics enabled & new profile = F && F = F   | metrics disabled & new profile = T && F = F   |
| F  | metrics enabled & old profile = F && T = F    | metrics disabled & old profile = T && T = T  |

*Testing done:*
Build new exe locally and run integration test against it locally, all profile check tests passed.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including READMEs and comments (where appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific environment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.