### PR TITLE
set dependabot to weekly schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,14 +17,14 @@ updates:
       - porting-assistant-nuget
       - nuget-org
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - package-ecosystem: "nuget"
     directory: "packages/csharp/PortingAssistant/PortingAssistant.Common"
     registries:
       - porting-assistant-nuget
       - nuget-org
     schedule:
-      interval: "daily"
+      interval: "weekly"
     ignore:
       - dependency-name: "Microsoft.AspNetCore.Mvc.NewtonsoftJson"
   - package-ecosystem: "nuget"
@@ -33,7 +33,7 @@ updates:
       - porting-assistant-nuget
       - nuget-org
     schedule:
-      interval: "daily"
+      interval: "weekly"
     ignore:
       - dependency-name: "Microsoft.AspNetCore.Mvc.NewtonsoftJson"
   - package-ecosystem: "nuget"
@@ -42,4 +42,4 @@ updates:
       - porting-assistant-nuget
       - nuget-org
     schedule:
-      interval: "daily"
+      interval: "weekly"


### PR DESCRIPTION
## Description
* Set dependabot to check for package updates on a weekly basis (checks on Monday by default)

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
