### PR TITLE
Add pre-trigger project data in assess solution/project request

### DIFF
--- a/packages/csharp/PortingAssistant/PortingAssistant.Common/Model/AnalyzeSolutionRequest.cs
+++ b/packages/csharp/PortingAssistant/PortingAssistant.Common/Model/AnalyzeSolutionRequest.cs
@@ -11,5 +11,23 @@ namespace PortingAssistant.Common.Model
         public string triggerType { get; set; }
 
         public AnalyzerSettings settings { get; set; }
+
+        public string[] preTriggerData { get; set; }
+    }
+    public class ProjectTableData
+    {
+        public string projectName { get; set; }
+        public string projectPath { get; set; }
+        public string solutionPath { get; set; }
+        public string targetFramework { get; set; }
+        public int? referencedProjects { get; set; }
+        public int? incompatiblePackages { get; set; }
+        public int? totalPackages { get; set; }
+        public int? incompatibleApis { get; set; }
+        public int? totalApis { get; set; }
+        public int? buildErrors { get; set; }
+        public int? portingActions { get; set; }
+        public bool ported { get; set; }
+        public bool buildFailed { get; set; }
     }
 }

--- a/packages/csharp/PortingAssistant/PortingAssistant.Common/Utils/TelemetryCollectionUtils.cs
+++ b/packages/csharp/PortingAssistant/PortingAssistant.Common/Utils/TelemetryCollectionUtils.cs
@@ -1,3 +1,4 @@
+using Newtonsoft.Json;
 using PortingAssistant.Client.Model;
 using PortingAssistant.Common.Model;
 using PortingAssistant.Telemetry.Model;
@@ -18,9 +19,9 @@ namespace PortingAssistant.Common.Utils
             TelemetryCollector.Collect<SolutionMetrics>(solutionMetrics);
         }
 
-        public static void CollectProjectMetrics(ProjectAnalysisResult projectAnalysisResult, AnalyzeSolutionRequest request, string tgtFramework)
+        public static void CollectProjectMetrics(ProjectAnalysisResult projectAnalysisResult, AnalyzeSolutionRequest request, string tgtFramework, ProjectTableData preTriggerData = null)
         {
-            var projectMetrics = createProjectMetric(request.runId, request.triggerType, tgtFramework, projectAnalysisResult);
+            var projectMetrics = createProjectMetric(request.runId, request.triggerType, tgtFramework, projectAnalysisResult, preTriggerData);
             TelemetryCollector.Collect<ProjectMetrics>(projectMetrics);
         }
 
@@ -64,7 +65,7 @@ namespace PortingAssistant.Common.Utils
                 PortingAssistantVersion = MetricsBase.Version
             };
         }
-        public static ProjectMetrics createProjectMetric(string runId, string triggerType, string tgtFramework, ProjectAnalysisResult projectAnalysisResult)
+        public static ProjectMetrics createProjectMetric(string runId, string triggerType, string tgtFramework, ProjectAnalysisResult projectAnalysisResult, ProjectTableData preTriggerData = null)
         {
             return new ProjectMetrics
             {
@@ -80,7 +81,10 @@ namespace PortingAssistant.Common.Utils
                 NumReferences = projectAnalysisResult.ProjectReferences.Count,
                 IsBuildFailed = projectAnalysisResult.IsBuildFailed,
                 CompatibilityResult = projectAnalysisResult.ProjectCompatibilityResult,
-                PortingAssistantVersion = MetricsBase.Version
+                PortingAssistantVersion = MetricsBase.Version,
+                PreTriggerApiInCompatibilityCount = preTriggerData?.incompatibleApis,
+                PreTriggerFramework = preTriggerData?.targetFramework,
+                PreTriggerBuildErrorCount = preTriggerData?.buildErrors
             };
         }
 

--- a/packages/csharp/PortingAssistant/PortingAssistant.Telemetry/Models/ProjectMetrics.cs
+++ b/packages/csharp/PortingAssistant/PortingAssistant.Telemetry/Models/ProjectMetrics.cs
@@ -22,5 +22,11 @@ namespace PortingAssistant.Telemetry.Model
         public List<String> SourceFrameworks { get; set; }
         [JsonProperty("compatibilityResult")]
         public ProjectCompatibilityResult CompatibilityResult { get; set; }
+        [JsonProperty("preTriggerApiInCompatibilityCount")]
+        public int? PreTriggerApiInCompatibilityCount  { get; set; }
+        [JsonProperty("preTriggerBuildErrorCount")]
+        public int? PreTriggerBuildErrorCount { get; set; }
+        [JsonProperty("preTriggerFramework")]
+        public string? PreTriggerFramework { get; set; }
     }
 }

--- a/packages/electron/src/electron-backend.ts
+++ b/packages/electron/src/electron-backend.ts
@@ -184,8 +184,8 @@ export const initConnection = (logger: any = console) => {
 
     ipcMain.handle(
       "analyzeSolution",
-      async (_event, solutionFilePath, runId, triggerType, settings) => {
-        const request = { solutionFilePath, runId, triggerType, settings };
+      async (_event, solutionFilePath, runId, triggerType, settings, preTriggerData) => {
+        const request = { solutionFilePath, runId, triggerType, settings, preTriggerData };
         const elapseTime = startTimer();
         logger.log(`REQUEST - analyzeSolution: ${JSON.stringify(request)}`);
         const response = await connection.send("analyzeSolution", request);

--- a/packages/electron/src/preload.ts
+++ b/packages/electron/src/preload.ts
@@ -115,8 +115,9 @@ contextBridge.exposeInMainWorld("backend", {
       continiousEnabled: boolean;
       actionsOnly: boolean;
       compatibleOnly: boolean;
-    }
-  ) => invokeBackend("analyzeSolution", solutionFilePath, runId, triggerType, settings),
+    },
+    preTriggerData: string[]
+  ) => invokeBackend("analyzeSolution", solutionFilePath, runId, triggerType, settings, preTriggerData),
   openSolutionInIDE: (solutionFilePath: string) =>
     invokeBackend("openSolutionInIDE", solutionFilePath),
   getFileContents: (sourceFilePath: string) =>

--- a/packages/react/src/bootstrapElectron.ts
+++ b/packages/react/src/bootstrapElectron.ts
@@ -58,7 +58,8 @@ export interface Backend {
       continiousEnabled: boolean;
       actionsOnly: boolean;
       compatibleOnly: boolean;
-    }
+    },
+    preTriggerData: string[]
   ) => Promise<Response<SolutionDetails, string>>;
   openSolutionInIDE: (solutionFilePath: string) => Promise<Response<boolean, string>>;
   getFileContents: (sourceFilePath: string) => Promise<string>;

--- a/packages/react/src/components/AddSolution/AddSolutionForm.tsx
+++ b/packages/react/src/components/AddSolution/AddSolutionForm.tsx
@@ -54,6 +54,7 @@ const ImportSolutionInternal: React.FC = () => {
                   actionsOnly: false,
                   compatibleOnly: false
                 },
+                preTriggerData:[],
                 force: true
               })
             );

--- a/packages/react/src/components/AssessSolution/AssessSolutionDashboard.tsx
+++ b/packages/react/src/components/AssessSolution/AssessSolutionDashboard.tsx
@@ -13,6 +13,7 @@ import { Project } from "../../models/project";
 import { SolutionDetails } from "../../models/solution";
 import { analyzeSolution, exportSolution, openSolutionInIDE } from "../../store/actions/backend";
 import { selectPortingLocation } from "../../store/selectors/portingSelectors";
+import { selectProjectTableData } from "../../store/selectors/tableSelectors";
 import { checkInternetAccess } from "../../utils/checkInternetAccess";
 import { getTargetFramework } from "../../utils/getTargetFramework";
 import { isLoaded, Loadable } from "../../utils/Loadable";
@@ -46,7 +47,10 @@ const AssessSolutionDashboardInternal: React.FC<Props> = ({ solution, projects }
 
   useNugetFlashbarMessages(projects);
   useApiAnalysisFlashbarMessage(solution);
-
+  
+  const projectsTable = usePortingAssistantSelector(state => selectProjectTableData(state, location.pathname));
+  let preTriggerDataArray: string[] = [];
+  projectsTable.forEach(element => {preTriggerDataArray.push(JSON.stringify(element));});
   const tabs = useMemo(
     () => [
       {
@@ -170,6 +174,7 @@ const AssessSolutionDashboardInternal: React.FC<Props> = ({ solution, projects }
                         actionsOnly: false,
                         compatibleOnly: false
                       },
+                      preTriggerData: preTriggerDataArray,
                       force: true
                     })
                   );

--- a/packages/react/src/components/Dashboard/DashboardTable.tsx
+++ b/packages/react/src/components/Dashboard/DashboardTable.tsx
@@ -20,13 +20,16 @@ import { externalUrls } from "../../constants/externalUrls";
 import { analyzeSolution, exportSolution, openSolutionInIDE, removeSolution } from "../../store/actions/backend";
 import { pushCurrentMessageUpdate, removeCurrentMessageUpdate } from "../../store/actions/error";
 import { removePortedSolution } from "../../store/actions/porting";
-import { selectSolutionToSolutionDetails } from "../../store/selectors/solutionSelectors";
-import { selectDashboardTableData } from "../../store/selectors/tableSelectors";
+import { selectSolutionToSolutionDetails} from "../../store/selectors/solutionSelectors";
+import { getErrorCounts, selectDashboardTableData, selectSolutionToApiAnalysis
+ } from "../../store/selectors/tableSelectors";
 import { checkInternetAccess } from "../../utils/checkInternetAccess";
 import { filteringCountText } from "../../utils/FilteringCountText";
+import { getCompatibleApi } from "../../utils/getCompatibleApi";
 import { getTargetFramework } from "../../utils/getTargetFramework";
 import { isLoaded } from "../../utils/Loadable";
 import { useNugetFlashbarMessages } from "../AssessShared/useNugetFlashbarMessages";
+import { TableData } from "../AssessSolution/ProjectsTable";
 import { InfoLink } from "../InfoLink";
 import { LinkComponent } from "../LinkComponent";
 import { TableHeader } from "../TableHeader";
@@ -53,12 +56,12 @@ const DashboardTableInternal: React.FC = () => {
   const dispatch = useDispatch();
   const history = useHistory();
   const solutionToSolutionDetails = useSelector(selectSolutionToSolutionDetails);
-
+  
   const tableData = useSelector(selectDashboardTableData);
   const targetFramework = getTargetFramework();
   useNugetFlashbarMessages();
   useSolutionFlashbarMessage(tableData);
-
+  const apiAnalysis = useSelector(selectSolutionToApiAnalysis); 
   const deleteSolution = useMemo(
     () => (solutionPath: string) => {
       dispatch(removeSolution(solutionPath));
@@ -75,8 +78,42 @@ const DashboardTableInternal: React.FC = () => {
           groupId: "assessSuccess"
         })
       );
+
+      let projectTableData: TableData[] = [];
+      const solutionDetails = solutionToSolutionDetails[solutionPath];
+      const projectToApiAnalysis = apiAnalysis[solutionPath];
+      if (isLoaded(solutionDetails)) {
+          projectTableData = solutionDetails.data.projects.map<TableData>(project => {
+            const apis = getCompatibleApi(
+              solutionDetails,
+              projectToApiAnalysis,
+              project.projectFilePath,
+              null,
+              targetFramework
+            );
+            return {
+              projectName: project.projectName || "-",
+              projectPath: project.projectFilePath || "-",
+              solutionPath: solutionPath || "-",
+              targetFramework: project.targetFrameworks?.join(", ") || "-",
+              referencedProjects: project.projectReferences?.length || 0,
+              incompatiblePackages: null,
+              totalPackages: project.packageReferences?.length || 0,
+              incompatibleApis: apis.isApisLoading ? null : apis.values[1] - apis.values[0],
+              totalApis: apis.values[1],
+              buildErrors: getErrorCounts(projectToApiAnalysis, project.projectFilePath, null),
+              portingActions: null,
+              ported: false,
+              buildFailed: false
+            };
+          });
+      }
+      
       const haveInternet = await checkInternetAccess(solutionPath, dispatch);
       if (haveInternet) {
+        let preTriggerDataArray: string[] = [];
+        projectTableData.forEach(element => {preTriggerDataArray.push(JSON.stringify(element));});
+
         dispatch(
           analyzeSolution.request({
             solutionPath: solutionPath,
@@ -89,6 +126,7 @@ const DashboardTableInternal: React.FC = () => {
               actionsOnly: false,
               compatibleOnly: false
             },
+            preTriggerData: preTriggerDataArray,
             force: true
           })
         );
@@ -176,7 +214,10 @@ const DashboardTableInternal: React.FC = () => {
               id="reassess-solution"
               key="reassess-solution"
               disabled={selectedItems.length === 0}
-              onClick={() => reassessSolution(selectedItems[0].path)}
+              onClick={() => {
+                
+                reassessSolution(selectedItems[0].path);
+              }}
               iconName="refresh"
             >
               Reassess solution

--- a/packages/react/src/components/PortProject/PortProjectDashboard.tsx
+++ b/packages/react/src/components/PortProject/PortProjectDashboard.tsx
@@ -37,7 +37,7 @@ const PortProjectDashboardInternal: React.FC<Props> = ({ solution, project, port
           setError("targetFramework", { type: "required", message: "Target Framework is required." });
           return;
         }
-        handlePortProjectSubmission(data, solution, [project], targetFramework.id, portingLocation, dispatch);
+        handlePortProjectSubmission(data, solution, [project], targetFramework.id, portingLocation, [], dispatch);
         history.push("/solutions");
       })}
     >

--- a/packages/react/src/components/PortShared/handlePortProjectSubmission.ts
+++ b/packages/react/src/components/PortShared/handlePortProjectSubmission.ts
@@ -16,6 +16,7 @@ import { checkInternetAccess } from "../../utils/checkInternetAccess";
 import { getPortingPath } from "../../utils/getPortingPath";
 import { getPortingSolutionPath } from "../../utils/getPortingSolutionPath";
 import { getTargetFramework } from "../../utils/getTargetFramework";
+import { TableData } from "../AssessSolution/ProjectsTable";
 
 export const handlePortProjectSubmission = async (
     data: Record<string, any>,
@@ -23,6 +24,7 @@ export const handlePortProjectSubmission = async (
     projects: Project[],
     targetFramework: string,
     portingLocation: PortingLocation,
+    preTriggerProjectsTableData: TableData[],
     dispatch: ReturnType<typeof useDispatch>
 ) => {
     dispatch(
@@ -35,6 +37,9 @@ export const handlePortProjectSubmission = async (
             dismissible: false
         })
     );
+
+    let preTriggerDataArray: string[] = [];
+    preTriggerProjectsTableData.forEach(element => {preTriggerDataArray.push(JSON.stringify(element));});
 
     const portingSolutionPath = getPortingSolutionPath(solution, portingLocation);
     if (portingLocation.type === "copy" && !window.electron.pathExists(portingSolutionPath)) {
@@ -136,6 +141,7 @@ export const handlePortProjectSubmission = async (
                         actionsOnly: false,
                         compatibleOnly: false
                     },
+                    preTriggerData: preTriggerDataArray,
                     force: true
                 })
             );

--- a/packages/react/src/components/PortSolution/PortSolutionDashboard.tsx
+++ b/packages/react/src/components/PortSolution/PortSolutionDashboard.tsx
@@ -8,6 +8,7 @@ import { usePortingAssistantSelector } from "../../createReduxStore";
 import { Project } from "../../models/project";
 import { SolutionDetails } from "../../models/solution";
 import { selectPortingLocation } from "../../store/selectors/portingSelectors";
+import { selectProjectTableData } from "../../store/selectors/tableSelectors";
 import { InfoLink } from "../InfoLink";
 import { handlePortProjectSubmission } from "../PortShared/handlePortProjectSubmission";
 import { NugetPackageUpgrades } from "../PortShared/NugetPackageUpgrades";
@@ -30,7 +31,8 @@ const PortSolutionDashboardInternal: React.FC<Props> = ({ solution, projects }) 
   const location = useLocation();
   const portingLocation = usePortingAssistantSelector(state => selectPortingLocation(state, location.pathname));
   const targetFramework = window.electron.getState("targetFramework");
-
+  const projectsTable= usePortingAssistantSelector(state => selectProjectTableData(state, location.pathname));
+  
   var hasWebForms = false;
 
   for(var project of projects) {
@@ -53,7 +55,7 @@ const PortSolutionDashboardInternal: React.FC<Props> = ({ solution, projects }) 
           setError("targetFramework", { type: "required", message: "Target Framework is required." });
           return;
         }
-        handlePortProjectSubmission(data, solution, projects, targetFramework.id, portingLocation, dispatch);
+        handlePortProjectSubmission(data, solution, projects, targetFramework.id, portingLocation, projectsTable, dispatch);
         history.push("/solutions");
       })}
     >

--- a/packages/react/src/store/actions/backend.ts
+++ b/packages/react/src/store/actions/backend.ts
@@ -14,6 +14,7 @@ export interface analyzeSolutionRequestPayload {
     compatibleOnly: boolean;
     actionsOnly: boolean;
   };
+  preTriggerData:string[];
   force?: boolean;
 }
 export interface analyzeSolutionSuccessPayload {

--- a/packages/react/src/store/sagas/backendSaga.ts
+++ b/packages/react/src/store/sagas/backendSaga.ts
@@ -113,6 +113,7 @@ function* handleInit(action: ReturnType<typeof init>) {
             actionsOnly: false,
             compatibleOnly: false
           },
+          preTriggerData:[], // ignore the preTriggerData at initialzation stage
           force: action.payload
         })
       );
@@ -183,7 +184,8 @@ function* handleAnalyzeSolution(action: ReturnType<typeof analyzeSolution.reques
       currentSolutionPath,
       action.payload.runId,
       action.payload.triggerType,
-      action.payload.settings
+      action.payload.settings,
+      action.payload.preTriggerData
     );
 
     if (solutionDetails.status.status === "Success") {
@@ -388,3 +390,4 @@ export default function* backendSaga() {
     watchPing()
   ]);
 }
+

--- a/packages/react/src/store/selectors/tableSelectors.ts
+++ b/packages/react/src/store/selectors/tableSelectors.ts
@@ -207,6 +207,15 @@ export const selectDashboardTableData = createSelector(
   }
 );
 
+export const selectSolutionToApiAnalysis = createSelector(
+  selectApiAnalysis,
+  (
+    solutionToApiAnalysis,
+  ) : SolutionToApiAnalysis => {
+    return solutionToApiAnalysis
+  }
+);
+
 export const selectProjectTableData = createCachedSelector(
   selectApiAnalysis,
   selectNugetPackages,


### PR DESCRIPTION
Add three additional properties in ProjectMetrics model:

 1. int? **PreTriggerApiInCompatibilityCount**  (Summarizes total api incompatibility count at project level)
       
 2. int? **PreTriggerBuildErrorCount** (Summarizes total build error count at project level)
       
 3. string? **PreTriggerFramework** (Previous framework name before porting. This is for fixing the heatmap issue in PortingRequest. )

Example of the one ProjectMetrics Json in portingAssistant-telemetry-xxxxxxxx.metrics file. 

`{"numNugets":9,"numReferences":0,"projectGuid":"4E-48-F6-CA-E4-06-E7-15-9F-48-D3-D1-49-87-0C-8F-63-B0-EC-48-35-A7-37-3E-4D-84-13-BE-7B-94-CF-D1","isBuildFailed":false,"projectType":"KnownToBeMSBuildFormat","sourceFrameworks":["net472"],"compatibilityResult":{"ProjectPath":"C:\\git\\TestProjects\\net472\\FormsAuthentication\\FormsAuthentication\\FormsAuthentication.csproj","IsPorted":false,"CodeEntityCompatibilityResults":[{"CodeEntityType":5,"Compatible":0,"Incompatible":2,"Unknown":0,"Actions":2,"Deprecated":0},{"CodeEntityType":2,"Compatible":0,"Incompatible":7,"Unknown":0,"Actions":0,"Deprecated":0},{"CodeEntityType":6,"Compatible":4,"Incompatible":6,"Unknown":1,"Actions":0,"Deprecated":0},{"CodeEntityType":8,"Compatible":0,"Incompatible":0,"Unknown":0,"Actions":0,"Deprecated":0},{"CodeEntityType":9,"Compatible":0,"Incompatible":0,"Unknown":0,"Actions":0,"Deprecated":0}]},**"preTriggerApiInCompatibilityCount":10,"preTriggerBuildErrorCount":1,"preTriggerFramework":"net472"**,"MetricsType":"Project","RunId":"dc63a87d-d8dc-43f2-8b50-2f0f282787ce","TriggerType":"UserRequest","PortingAssistantVersion":"1.6.4","TargetFramework":"net6.0","TimeStamp":"03/28/2022 18:00","UniqueId":"45-9D-9A-FF-00-80-25-EF-69-8D-0C-3E-D7-B9-E6-EA-E9-C2-51-C1-73-6F-BB-0B-31-C2-08-2C-16-54-C2-B4"}`

Main Changes:

1. I can not add ProjectTableData[] type to analyzeSolutionRequestPayload directly in react.  So each pretrigger request data (ProjectTableData) is Deserialized into json string,  and serialized to object in Csharp request model. 

2. I can not use selectApiAnalysis (packages\react\src\store\selectors\_solutionSelectors.ts_) in DashboardTable.tsx directly.  Compile error will occur if calling useSelector(selectApiAnalysis).  Really want to know why. The workaround is to wrap the method "SolutionToApiAnalysis" in packages\react\src\store\selectors\_tableSelectors.ts._ Then the project apiAnalysis will be available in main dashboard table.

Some Findings
1. If only choose partial projects to port (not porting entire solution), the "**PortingRequest**" still re-assess all projects.

2. OnSubmit() Form function is not called in packages\react\src\components\PortProject\PortProjectDashboard.tsx.   If only choose partial projects to port, the Port ButtonClick still call the logic in PortSolutionDashboard.tsx.