### PR TITLE
fix: dedup some log upload errors and use refactored telemetry

### DIFF
--- a/packages/csharp/PortingAssistant/PortingAssistant.Api/PortingAssistant.Api.csproj
+++ b/packages/csharp/PortingAssistant/PortingAssistant.Api/PortingAssistant.Api.csproj
@@ -7,8 +7,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="ElectronCgi.DotNet" Version="1.0.3" />
-		<PackageReference Include="PortingAssistant.Client.Client" Version="2.3.9" />
-		<PackageReference Include="PortingAssistant.Client.Telemetry" Version="2.3.9" />
+		<PackageReference Include="PortingAssistant.Client.Client" Version="2.4.2-alpha-g7b80e67d7c" />
+		<PackageReference Include="PortingAssistant.Client.Telemetry" Version="2.4.2-alpha-g7b80e67d7c" />
 		<PackageReference Include="Serilog.Sinks.RollingFile" Version="3.3.0" />
 		<PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
 	</ItemGroup>

--- a/packages/csharp/PortingAssistant/PortingAssistant.Api/Program.cs
+++ b/packages/csharp/PortingAssistant/PortingAssistant.Api/Program.cs
@@ -44,11 +44,12 @@ namespace PortingAssistant.Api
                 .MinimumLevel.Debug()
                 .WriteTo.RollingFile(
                     Path.Combine(args[2], "logs", "portingAssistant-assessment-{Date}.log"),
-                    outputTemplate: outputTemplate)
+                    outputTemplate: outputTemplate,
+                    fileSizeLimitBytes: 1000000)
                 .WriteTo.Logger(lc => lc.MinimumLevel.Error().WriteTo.RollingFile(
-                    Path.Combine(args[2], "logs", "portingAssistant-backend-{Date}.log"), 
-                    outputTemplate: outputTemplate)
-                    );
+                    Path.Combine(args[2], "logs", "portingAssistant-backend-{Date}.log"),
+                    outputTemplate: outputTemplate,
+                    fileSizeLimitBytes: 1000000));
 
             if (isConsole)
             {

--- a/packages/csharp/PortingAssistant/PortingAssistant.Common/PortingAssistant.Common.csproj
+++ b/packages/csharp/PortingAssistant/PortingAssistant.Common/PortingAssistant.Common.csproj
@@ -15,8 +15,8 @@
     <Folder Include="Listener\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="PortingAssistant.Client.Client" Version="2.3.9" />
-    <PackageReference Include="PortingAssistant.Client.Telemetry" Version="2.3.9" />
+    <PackageReference Include="PortingAssistant.Client.Client" Version="2.4.2-alpha-g7b80e67d7c" />
+    <PackageReference Include="PortingAssistant.Client.Telemetry" Version="2.4.2-alpha-g7b80e67d7c" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.3" />
   </ItemGroup>

--- a/packages/csharp/PortingAssistant/PortingAssistant.Telemetry/PortingAssistant.Telemetry.csproj
+++ b/packages/csharp/PortingAssistant/PortingAssistant.Telemetry/PortingAssistant.Telemetry.csproj
@@ -8,8 +8,9 @@
   <ItemGroup>
     <PackageReference Include="ElectronCgi.DotNet" Version="1.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.3" />
-    <PackageReference Include="PortingAssistant.Client.Client" Version="2.3.9" />
-    <PackageReference Include="PortingAssistant.Client.Telemetry" Version="2.3.9" />
+    <PackageReference Include="PortingAssistant.Client.Client" Version="2.4.2-alpha-g7b80e67d7c" />
+    <PackageReference Include="PortingAssistant.Client.Telemetry" Version="2.4.2-alpha-g7b80e67d7c" />
+    <PackageReference Include="Serilog.Sinks.RollingFile" Version="3.3.0" />
     <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
     <PackageReference Include="AWSSDK.Core" Version="3.7.9" />
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />

--- a/packages/csharp/PortingAssistant/PortingAssistant.Telemetry/Program.cs
+++ b/packages/csharp/PortingAssistant/PortingAssistant.Telemetry/Program.cs
@@ -47,7 +47,8 @@ namespace PortingAssistant.Telemetry
                 .MinimumLevel.Debug()
                 .WriteTo.RollingFile(
                     Path.Combine(args[2], "logs", "portingAssistant-telemetry-{Date}.log"),
-                    outputTemplate: outputTemplate);
+                    outputTemplate: outputTemplate,
+                    fileSizeLimitBytes: 1000000);
 
             Log.Logger = logConfiguration.CreateLogger();
 

--- a/packages/csharp/PortingAssistant/PortingAssistant.Telemetry/Program.cs
+++ b/packages/csharp/PortingAssistant/PortingAssistant.Telemetry/Program.cs
@@ -5,6 +5,7 @@ using PortingAssistantExtensionTelemetry.Model;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using Serilog;
 
 namespace PortingAssistant.Telemetry
 {
@@ -40,17 +41,36 @@ namespace PortingAssistant.Telemetry
                 MetricsFilePath = Path.Combine(metricsFolder, $"portingAssistant-telemetry-{DateTime.Today.ToString("yyyyMMdd")}.metrics"),
                 Suffix = new List<string>() { ".log", ".metrics" }
             };
-            var lastReadTokenFile = Path.Combine(teleConfig.LogsPath, "lastToken.json");
-            string prefix = portingAssistantPortingConfiguration.PortingAssistantMetrics["Prefix"].ToString();
-            
+
+            var outputTemplate = "[{Timestamp:yyyy-MM-dd HH:mm:ss} {Level:u3}] {SourceContext}: {Message:lj}{NewLine}{Exception}";
+            var logConfiguration = new LoggerConfiguration().Enrich.FromLogContext()
+                .MinimumLevel.Debug()
+                .WriteTo.RollingFile(
+                    Path.Combine(args[2], "logs", "portingAssistant-telemetry-{Date}.log"),
+                    outputTemplate: outputTemplate);
+
+            Log.Logger = logConfiguration.CreateLogger();
+
             var logTimer = new System.Timers.Timer();
             logTimer.Interval = Convert.ToDouble(portingAssistantPortingConfiguration.PortingAssistantMetrics["LogTimerInterval"].ToString());
 
-            logTimer.Elapsed += (source, e) => LogUploadUtils.OnTimedEvent(source, e, teleConfig, lastReadTokenFile, profile, useDefaultCreds, prefix, shareMetric);
-
+            LogUploadUtils.InitializeUploader(
+                shareMetric,
+                teleConfig,
+                profile,
+                useDefaultCreds,
+                Log.Logger);
+            logTimer.Elapsed += LogUploadUtils.OnTimedEvent;
             logTimer.AutoReset = true;
-
             logTimer.Enabled = true;
+
+            var writeLogErrorsTimer = new System.Timers.Timer
+            {
+                Interval = 300000,
+                AutoReset = true,
+                Enabled = true
+            };
+            writeLogErrorsTimer.Elapsed += LogUploadUtils.WriteLogUploadErrors;
 
             _connection.Listen();
         }

--- a/packages/csharp/PortingAssistant/PortingAssistant.Telemetry/Utils/LogUploadUtils.cs
+++ b/packages/csharp/PortingAssistant/PortingAssistant.Telemetry/Utils/LogUploadUtils.cs
@@ -17,23 +17,23 @@ namespace PortingAssistant.Telemetry.Utils
 
             string typeOfLog = (fName.Split('-').Length > 1) ? fName.Split('-')[1] : String.Empty;
 
-            if (typeOfLog == "telemetry")
+            if (typeOfLog.Equals("telemetry", StringComparison.OrdinalIgnoreCase))
             {
                 logName = "portingAssistant-metrics";
             }
-            else if (typeOfLog == "backend")
+            else if (typeOfLog.Equals("backend", StringComparison.OrdinalIgnoreCase))
             {
                 logName = "portingAssistant-backend-logs";
             }
-            else if (typeOfLog == "electron")
+            else if (typeOfLog.Equals("electron", StringComparison.OrdinalIgnoreCase))
             {
                 logName = "electron-logs";
             }
-            else if (typeOfLog == "react")
+            else if (typeOfLog.Equals("react", StringComparison.OrdinalIgnoreCase))
             {
                 logName = "react-errors";
             }
-            else if (typeOfLog == "client")
+            else if (typeOfLog.Equals("client", StringComparison.OrdinalIgnoreCase))
             {
                 var suffix = Path.GetExtension(file);
                 logName = suffix == ".log" ? "portingAssistant-client-cli-logs" : "portingAssistant-client-cli-metrics";

--- a/packages/csharp/PortingAssistant/PortingAssistant.Telemetry/Utils/LogUploadUtils.cs
+++ b/packages/csharp/PortingAssistant/PortingAssistant.Telemetry/Utils/LogUploadUtils.cs
@@ -1,254 +1,73 @@
-using Amazon.Runtime;
-using Amazon.Runtime.CredentialManagement;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using PortingAssistantExtensionTelemetry.Model;
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net;
-using System.Net.Http;
 using System.Net.NetworkInformation;
-using System.Text;
-using System.Threading.Tasks;
 using PortingAssistant.Client.Telemetry;
-using Amazon;
+using Serilog;
 
 namespace PortingAssistant.Telemetry.Utils
 {
     public static class LogUploadUtils
     {
-        private static Boolean IsFileLocked(FileInfo file)
+        private static string GetLogName(string file)
         {
-            FileStream stream = null;
+            var fName = Path.GetFileNameWithoutExtension(file);
+            var logName = "";
 
-            try
+            string typeOfLog = (fName.Split('-').Length > 1) ? fName.Split('-')[1] : String.Empty;
+
+            if (typeOfLog == "telemetry")
             {
-                stream = file.Open
-                (
-                    FileMode.Open,
-                    FileAccess.Read,
-                    FileShare.ReadWrite
-                );
+                logName = "portingAssistant-metrics";
             }
-            catch (IOException)
+            else if (typeOfLog == "backend")
             {
-                return true;
+                logName = "portingAssistant-backend-logs";
             }
-            finally
+            else if (typeOfLog == "electron")
             {
-                if (stream != null)
-                    stream.Close();
+                logName = "electron-logs";
             }
-            return false;
+            else if (typeOfLog == "react")
+            {
+                logName = "react-errors";
+            }
+            else if (typeOfLog == "client")
+            {
+                var suffix = Path.GetExtension(file);
+                logName = suffix == ".log" ? "portingAssistant-client-cli-logs" : "portingAssistant-client-cli-metrics";
+            }
+            return logName;
         }
 
-        private static async Task<bool> PutLogData
-            (
-            string logName,
-            string logData,
+        private static Uploader _uploader;
+
+        public static void InitializeUploader(bool shareMetric,
+            TelemetryConfiguration config,
             string profile,
             bool enabledDefaultCredentials,
-            TelemetryConfiguration telemetryConfiguration
-            )
+            ILogger logger)
         {
-            const string PathTemplate = "/put-log-data";
-            try
+            TelemetryClientFactory.TryGetClient(profile, config, out ITelemetryClient client, enabledDefaultCredentials);
+            _uploader = new Uploader(config, client, logger, shareMetric)
             {
-                var chain = new CredentialProfileStoreChain();
-                AWSCredentials awsCredentials;
-                if (enabledDefaultCredentials)
-                {
-                    awsCredentials = FallbackCredentialsFactory.GetCredentials();
-                    if (awsCredentials == null)
-                    {
-                        Console.WriteLine("Invalid Credentials.");
-                        return false;
-                    }
-                }
-                else {
-                    var profileName = profile;
-                    if (!chain.TryGetAWSCredentials(profileName, out awsCredentials))
-                    {
-                        Console.WriteLine("Invalid Credentials.");
-                        return false;
-                    }
-                }
-                var region = telemetryConfiguration.Region;
-                  dynamic requestMetadata = new JObject();
-                  requestMetadata.version = "1.0";
-                  requestMetadata.service = telemetryConfiguration.ServiceName;
-                  requestMetadata.token = "12345678";
-                  requestMetadata.description = telemetryConfiguration.Description;
-
-                  dynamic log = new JObject();
-                  log.timestamp = DateTime.Now.ToString();
-                  log.logName = logName;
-                  var logDataInBytes = System.Text.Encoding.UTF8.GetBytes(logData);
-                  log.logData = System.Convert.ToBase64String(logDataInBytes);
-
-                  dynamic body = new JObject();
-                  body.requestMetadata = requestMetadata;
-                  body.log = log;
-
-                  var requestContent = new StringContent(body.ToString(Formatting.None), Encoding.UTF8, "application/json");
-
-                  var config = new TelemetryClientConfig
-                  {
-                      RegionEndpoint = RegionEndpoint.GetBySystemName(region),
-                      MaxErrorRetry = 2,
-                      ServiceURL = telemetryConfiguration.InvokeUrl,
-                  };
-                  var client = new TelemetryClient(awsCredentials, config);
-                  var contentString = await requestContent.ReadAsStringAsync();
-                  var telemetryRequest = new TelemetryRequest(telemetryConfiguration.ServiceName, contentString);
-                  var telemetryResponse = await client.SendAsync(telemetryRequest);
-                  if (telemetryResponse.HttpStatusCode != HttpStatusCode.OK)
-                  {
-                      Console.WriteLine("Http response failed with status code: " + telemetryResponse.HttpStatusCode.ToString());
-                  }
-                  
-                  return telemetryResponse.HttpStatusCode == HttpStatusCode.OK;
-             }
-            catch (Exception ex)
-            {
-                Console.WriteLine(ex.Message);
-                return false;
-            }
+                GetLogName = GetLogName
+            };
         }
 
         public static void OnTimedEvent(
             Object source, 
-            System.Timers.ElapsedEventArgs e, 
-            TelemetryConfiguration teleConfig, 
-            string lastReadTokenFile, 
-            string profile, 
-            bool enabledDefaultCredentials,
-            string prefix,
-            bool shareMetric)
+            System.Timers.ElapsedEventArgs e)
         {
-            try
-            {
-                if (!shareMetric) return;
-                // Get files in directory and filter based on Suffix
-                string[] fileEntries = Directory.GetFiles(teleConfig.LogsPath).Where(f => (
-                  teleConfig.Suffix.ToArray().Any(x => f.EndsWith(x))
-                  )).ToArray();
-                // Get or Create fileLineNumberMap
-                var fileLineNumberMap = new Dictionary<string, int>();
-                if (File.Exists(lastReadTokenFile))
-                {
-                    fileLineNumberMap = JsonConvert.DeserializeObject<Dictionary<string, int>>(File.ReadAllText(lastReadTokenFile));
-                }
-                var initLineNumber = 0;
-                foreach (var file in fileEntries)
-                {
-                    var fName = Path.GetFileNameWithoutExtension(file);
-                    var fileExtension = Path.GetExtension(file);
-                    var logName = prefix;
+            _uploader.Run();
+        }
 
-                    // Check which type of log file and set the prefix
-                    if (fName == "main")
-                    {
-                        continue;
-                    }
-                    else
-                    {
-
-                        string typeOfLog = (fName.Split('-').Length > 1) ? fName.Split('-')[1]: String.Empty;
-                        if (typeOfLog == "assessment")
-                        {
-                            continue;
-                        }
-                        else if (typeOfLog == "telemetry")
-                        {
-                            logName = "portingAssistant-metrics";
-                        }
-                        else if (typeOfLog == "backend")
-                        {
-                            logName = "portingAssistant-backend-logs";
-                        }
-                        else if (typeOfLog == "electron")
-                        {
-                            logName = "electron-logs";
-                        }
-                        else if (typeOfLog == "react")
-                        {
-                            logName = "react-errors";
-                        }
-                        else if (typeOfLog == "client")
-                        {
-                            var suffix = Path.GetExtension(file);
-                            logName = suffix == ".log" ? "portingAssistant-client-cli-logs" : "portingAssistant-client-cli-metrics";
-                        }
-                    }
-
-                    var logs = new ArrayList();
-
-                    // Add new files to fileLineNumberMap
-                    if (!fileLineNumberMap.ContainsKey(file))
-                    {
-                        fileLineNumberMap[file] = 0;
-                    }
-                    initLineNumber = fileLineNumberMap[file];
-                    FileInfo fileInfo = new FileInfo(file);
-                    var success = false;
-                    if (!IsFileLocked(fileInfo))
-                    {
-                        using (FileStream fs = fileInfo.Open(FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
-                        {
-                            using (StreamReader reader = new StreamReader(fs))
-                            {
-                                string line = null;
-                                int currLineNumber = 0;
-                                for (; currLineNumber < initLineNumber; currLineNumber++)
-                                {
-                                    line = reader.ReadLine();
-                                    if (line == null)
-                                    {
-                                        return;
-                                    }
-                                }
-
-                                line = reader.ReadLine();
-
-                                // If put-log api works keep sending logs else wait and do it next time
-                                while (line != null && logs.Count <= 1000)
-                                {
-                                    currLineNumber++;
-                                    logs.Add(line);
-                                    line = reader.ReadLine();
-
-                                    // send 1000 lines of logs each time when there are large files
-                                    if (logs.Count >= 1000)
-                                    {
-                                        // logs.TrimToSize();
-                                        success = PutLogData(logName, JsonConvert.SerializeObject(logs), profile, enabledDefaultCredentials, teleConfig).Result;
-                                        if (success) { logs = new ArrayList(); };
-                                    }
-                                }
-
-                                if (logs.Count != 0)
-                                {
-                                    success = PutLogData(logName, JsonConvert.SerializeObject(logs), profile, enabledDefaultCredentials, teleConfig).Result;
-                                }
-                                if (success)
-                                {
-                                    fileLineNumberMap[file] = currLineNumber;
-                                    string jsonString = JsonConvert.SerializeObject(fileLineNumberMap);
-                                    File.WriteAllText(lastReadTokenFile, jsonString);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine(ex.Message);
-            }
+        public static void WriteLogUploadErrors(
+            Object source,
+            System.Timers.ElapsedEventArgs e)
+        {
+            _uploader.WriteLogUploadErrors();
         }
 
         public static string getUniqueIdentifier()

--- a/packages/csharp/PortingAssistant/PortingAssistant.Telemetry/Utils/LogUploadUtils.cs
+++ b/packages/csharp/PortingAssistant/PortingAssistant.Telemetry/Utils/LogUploadUtils.cs
@@ -41,7 +41,7 @@ namespace PortingAssistant.Telemetry.Utils
             return logName;
         }
 
-        private static Uploader _uploader;
+        public static Uploader Uploader;
 
         public static void InitializeUploader(bool shareMetric,
             TelemetryConfiguration config,
@@ -50,7 +50,7 @@ namespace PortingAssistant.Telemetry.Utils
             ILogger logger)
         {
             TelemetryClientFactory.TryGetClient(profile, config, out ITelemetryClient client, enabledDefaultCredentials);
-            _uploader = new Uploader(config, client, logger, shareMetric)
+            Uploader = new Uploader(config, client, logger, shareMetric)
             {
                 GetLogName = GetLogName
             };
@@ -60,14 +60,14 @@ namespace PortingAssistant.Telemetry.Utils
             Object source, 
             System.Timers.ElapsedEventArgs e)
         {
-            _uploader.Run();
+            Uploader.Run();
         }
 
         public static void WriteLogUploadErrors(
             Object source,
             System.Timers.ElapsedEventArgs e)
         {
-            _uploader.WriteLogUploadErrors();
+            Uploader.WriteLogUploadErrors();
         }
 
         public static string getUniqueIdentifier()

--- a/packages/csharp/PortingAssistant/PortingAssistant.UnitTests/PortingAssistant.UnitTests.csproj
+++ b/packages/csharp/PortingAssistant/PortingAssistant.UnitTests/PortingAssistant.UnitTests.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="PortingAssistant.Client.Client" Version="2.4.2-alpha-g7b80e67d7c" />
     <PackageReference Include="PortingAssistant.Client.Telemetry" Version="2.4.2-alpha-g7b80e67d7c" />
+    <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/packages/csharp/PortingAssistant/PortingAssistant.UnitTests/PortingAssistant.UnitTests.csproj
+++ b/packages/csharp/PortingAssistant/PortingAssistant.UnitTests/PortingAssistant.UnitTests.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="PortingAssistant.Client.Client" Version="2.3.9" />
-    <PackageReference Include="PortingAssistant.Client.Telemetry" Version="2.3.9" />
+    <PackageReference Include="PortingAssistant.Client.Client" Version="2.4.2-alpha-g7b80e67d7c" />
+    <PackageReference Include="PortingAssistant.Client.Telemetry" Version="2.4.2-alpha-g7b80e67d7c" />
   </ItemGroup>
 
   <ItemGroup>

--- a/packages/csharp/PortingAssistant/PortingAssistant.UnitTests/TelemetryUploadTests.cs
+++ b/packages/csharp/PortingAssistant/PortingAssistant.UnitTests/TelemetryUploadTests.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.IO;
+using NUnit.Framework;
+using PortingAssistant.Telemetry.Utils;
+using PortingAssistantExtensionTelemetry.Model;
+using Serilog;
+
+namespace PortingAssistant.UnitTests
+{
+    public class TelemetryUploadTests
+    {
+        [Test]
+        public void TestLogUploadUtilGetName()
+        {
+            var roamingFolder = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            var logs = Path.Combine(roamingFolder, "Porting Assistant for .NET", "logs");
+            var config = new TelemetryConfiguration
+            {
+                InvokeUrl = "https://localhost",
+                Region = "us-east-1",
+                ServiceName = "encore",
+                Description = "Porting Assistant for .NET Telemetry Logs",
+                LogsPath = logs
+            };
+
+            var outputTemplate = "[{Timestamp:yyyy-MM-dd HH:mm:ss} {Level:u3}] {SourceContext}: {Message:lj}{NewLine}{Exception}";
+            var logConfiguration = new LoggerConfiguration()
+                .WriteTo.Debug(outputTemplate: outputTemplate)
+                .MinimumLevel.Debug();
+            Log.Logger = logConfiguration.CreateLogger();
+            LogUploadUtils.InitializeUploader(true, config, "default", false, Log.Logger);
+            Assert.AreEqual("portingAssistant-backend-logs", LogUploadUtils.Uploader.GetLogName("portingAssistant-backend-20220801.log"));
+            Assert.AreEqual("portingAssistant-metrics", LogUploadUtils.Uploader.GetLogName("portingAssistant-telemetry-20220801.metrics"));
+            Assert.AreEqual("electron-logs", LogUploadUtils.Uploader.GetLogName("portingAssistant-electron-2022-08-01.log"));
+            Assert.AreEqual("react-errors", LogUploadUtils.Uploader.GetLogName("portingAssistant-react-2022-08-01.log"));
+
+        }
+    }
+}

--- a/packages/csharp/PortingAssistant/PortingAssistant.VisualStudio/PortingAssistant.VisualStudio.csproj
+++ b/packages/csharp/PortingAssistant/PortingAssistant.VisualStudio/PortingAssistant.VisualStudio.csproj
@@ -11,8 +11,8 @@
 			<!-- This package is mostly COM definitions which can be loaded in .NET 5 runtime just fine -->
 			<NoWarn>NU1701</NoWarn>
 		</PackageReference>
-		<PackageReference Include="PortingAssistant.Client.Client" Version="2.3.9" />
-		<PackageReference Include="PortingAssistant.Client.Telemetry" Version="2.3.9" />
+		<PackageReference Include="PortingAssistant.Client.Client" Version="2.4.2-alpha-g7b80e67d7c" />
+		<PackageReference Include="PortingAssistant.Client.Telemetry" Version="2.4.2-alpha-g7b80e67d7c" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
*Description of changes:*
Push telemetry upload logic into PA Client Uploader class, write errors encountered during telemetry upload to log file single time during application shutdown.

*Testing done:*
Added unit test to check get log name function, and manually tested that log upload still behaves the same

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including READMEs and comments (where appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific environment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.