### PR TITLE
feat: added path too long check in both react and C#.

### DIFF
--- a/packages/csharp/PortingAssistant/PortingAssistant.Common/Utils/PortingAssistantUtils.cs
+++ b/packages/csharp/PortingAssistant/PortingAssistant.Common/Utils/PortingAssistantUtils.cs
@@ -33,14 +33,14 @@ namespace PortingAssistant.Common.Utils
 
         public static void CopyDirectory(string solutionPath, string destinationPath)
         {
-            if (solutionPath == "")
+            if (string.IsNullOrEmpty(solutionPath))
             {
-                throw new ArgumentNullException(nameof(solutionPath), "The solution path length is empty.");
+                throw new ArgumentNullException(nameof(solutionPath), "The solution path length cannot be null or empty.");
             }
 
-            if (destinationPath == "")
+            if (string.IsNullOrEmpty(destinationPath))
             {
-                throw new ArgumentNullException(nameof(destinationPath), "The destination path length is empty.");
+                throw new ArgumentNullException(nameof(destinationPath), "The destination path length cannot be null or empty.");
             }
 
             string slnDirPath = Directory.GetParent(solutionPath).FullName;

--- a/packages/csharp/PortingAssistant/PortingAssistant.Common/Utils/PortingAssistantUtils.cs
+++ b/packages/csharp/PortingAssistant/PortingAssistant.Common/Utils/PortingAssistantUtils.cs
@@ -33,7 +33,16 @@ namespace PortingAssistant.Common.Utils
 
         public static void CopyDirectory(string solutionPath, string destinationPath)
         {
-           
+            if (solutionPath == "")
+            {
+                throw new ArgumentNullException(nameof(solutionPath), "The solution path length is empty.");
+            }
+
+            if (destinationPath == "")
+            {
+                throw new ArgumentNullException(nameof(destinationPath), "The destination path length is empty.");
+            }
+
             string slnDirPath = Directory.GetParent(solutionPath).FullName;
 
             DirectoryInfo directoryInfo = new DirectoryInfo(slnDirPath);

--- a/packages/csharp/PortingAssistant/PortingAssistant.Common/Utils/PortingAssistantUtils.cs
+++ b/packages/csharp/PortingAssistant/PortingAssistant.Common/Utils/PortingAssistantUtils.cs
@@ -10,6 +10,7 @@ namespace PortingAssistant.Common.Utils
     public static class PortingAssistantUtils
     {
         public static bool cancel = false;
+        private const int MaxPathLength = 260;
         public static string FindFiles(string targetDirectory, string fileName)
         {
             // Process the list of files found in the directory.
@@ -32,13 +33,13 @@ namespace PortingAssistant.Common.Utils
 
         public static void CopyDirectory(string solutionPath, string destinationPath)
         {
-            if (solutionPath.Length > 260)
+            if (solutionPath.Length > MaxPathLength)
             {
-                throw new PathTooLongException("The solution path length cannot exceed 260 characters. Please try a location that has a shorter path.");
+                throw new PathTooLongException($"The solution path length cannot exceed {MaxPathLength} characters. Please try a location that has a shorter path.");
             }
-            else if (destinationPath.Length > 260)
+            if (Path.GetFileName(solutionPath).Length + destinationPath.Length > MaxPathLength)
             {
-                throw new PathTooLongException("The destination path length cannot exceed 260 characters. Please try a location that has a shorter path.");
+                throw new PathTooLongException($"The destination path length cannot exceed {MaxPathLength} characters. Please try a location that has a shorter path.");
             }
             string slnDirPath = Directory.GetParent(solutionPath).FullName;
 

--- a/packages/csharp/PortingAssistant/PortingAssistant.Common/Utils/PortingAssistantUtils.cs
+++ b/packages/csharp/PortingAssistant/PortingAssistant.Common/Utils/PortingAssistantUtils.cs
@@ -32,6 +32,14 @@ namespace PortingAssistant.Common.Utils
 
         public static void CopyDirectory(string solutionPath, string destinationPath)
         {
+            if (solutionPath.Length > 260)
+            {
+                throw new PathTooLongException("The solution path length cannot exceed 260 characters. Please try a location that has a shorter path.");
+            }
+            else if (destinationPath.Length > 260)
+            {
+                throw new PathTooLongException("The destination path length cannot exceed 260 characters. Please try a location that has a shorter path.");
+            }
             string slnDirPath = Directory.GetParent(solutionPath).FullName;
 
             CopyFolderToTemp(Path.GetFileName(solutionPath), slnDirPath, destinationPath);

--- a/packages/csharp/PortingAssistant/PortingAssistant.Common/Utils/PortingAssistantUtils.cs
+++ b/packages/csharp/PortingAssistant/PortingAssistant.Common/Utils/PortingAssistantUtils.cs
@@ -33,15 +33,18 @@ namespace PortingAssistant.Common.Utils
 
         public static void CopyDirectory(string solutionPath, string destinationPath)
         {
-            if (solutionPath.Length > MaxPathLength)
-            {
-                throw new PathTooLongException($"The solution path length cannot exceed {MaxPathLength} characters. Please try a location that has a shorter path.");
-            }
-            if (Path.GetFileName(solutionPath).Length + destinationPath.Length > MaxPathLength)
-            {
-                throw new PathTooLongException($"The destination path length cannot exceed {MaxPathLength} characters. Please try a location that has a shorter path.");
-            }
+           
             string slnDirPath = Directory.GetParent(solutionPath).FullName;
+
+            DirectoryInfo directoryInfo = new DirectoryInfo(slnDirPath);
+            var allFiles = directoryInfo.EnumerateFiles("*.*", SearchOption.AllDirectories);
+            string longestFileName = allFiles.OrderByDescending(file => file.FullName.Length).FirstOrDefault().FullName;
+            string longestFileNameWithoutParentFolder = longestFileName.Replace(slnDirPath, "").TrimStart('\\');
+            string longestFileNameInDestinationFolder = Path.Combine(destinationPath, longestFileNameWithoutParentFolder);
+            if (longestFileNameInDestinationFolder.Length >= 260)
+            {
+                throw new PathTooLongException($"The destination path length cannot exceed {MaxPathLength - 1} characters. Please try a location that has a shorter path.");
+            }
 
             CopyFolderToTemp(Path.GetFileName(solutionPath), slnDirPath, destinationPath);
 

--- a/packages/csharp/PortingAssistant/PortingAssistant.UnitTests/PortingAssistantUtilsTests.cs
+++ b/packages/csharp/PortingAssistant/PortingAssistant.UnitTests/PortingAssistantUtilsTests.cs
@@ -13,12 +13,14 @@ namespace PortingAssistant.UnitTests
     public class PortingAssistantUtilsTests
     {
         private static Random random = new Random();
+        private const int MaxPathLength = 260;
+
 
         [Test]
         public void TestSolutionPathTooLongWillThrowException()
         {
-            var solutionPath = RandomString(280);
-            var destinationPath = "xx";
+            var solutionPath = RandomString(265);
+            var destinationPath = "xx/yy.sln";
             try
             {
                 PortingAssistantUtils.CopyDirectory(solutionPath, destinationPath);
@@ -26,15 +28,16 @@ namespace PortingAssistant.UnitTests
             catch (Exception e)
             {
                 Assert.AreEqual(e.Message,
-                    "The solution path length cannot exceed 260 characters. Please try a location that has a shorter path.");
+                    $"The solution path length cannot exceed {MaxPathLength} characters. Please try a location that has a shorter path.");
             }
         }
 
         [Test]
-        public void TestDestinationPathTooLongWillThrowException()
+        public void TestFileNamePlusDestinationPathTooLongWillThrowException()
         {
-            var solutionPath = "xx";
-            var destinationPath = RandomString(280);
+            var solutionPath = "xx/yy.sln";
+            var destinationPath = RandomString(258);
+
             try
             {
                 PortingAssistantUtils.CopyDirectory(solutionPath, destinationPath);
@@ -42,7 +45,7 @@ namespace PortingAssistant.UnitTests
             catch (Exception e)
             {
                 Assert.AreEqual(e.Message,
-                    "The destination path length cannot exceed 260 characters. Please try a location that has a shorter path.");
+                    $"The destination path length cannot exceed {MaxPathLength} characters. Please try a location that has a shorter path.");
             }
         }
 

--- a/packages/csharp/PortingAssistant/PortingAssistant.UnitTests/PortingAssistantUtilsTests.cs
+++ b/packages/csharp/PortingAssistant/PortingAssistant.UnitTests/PortingAssistantUtilsTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using Microsoft.CodeAnalysis;
 using NUnit.Framework;
 using PortingAssistant.Common.Utils;
 
@@ -30,13 +31,39 @@ namespace PortingAssistant.UnitTests
         public void TestLongestFileNamePlusDestinationPathEqualToMaxWillThrowPathTooLongException()
         {
             var solutionPath = "cs/yy.sln";
-            var destinationPath = @"D:\" + RandomString(255);
+            var destinationPath = @"D:\" + RandomString(195);
 
             var ex = Assert.Throws<PathTooLongException>(() =>
             {
                 PortingAssistantUtils.CopyDirectory(solutionPath, destinationPath);
             });
             Assert.AreEqual(ex.Message, $"The destination path length cannot exceed {MaxPathLength - 1} characters. Please try a location that has a shorter path.");
+        }
+
+        [Test]
+        public void TestEmptySolutionPathWillThrowException()
+        {
+            var solutionPath = "";
+            var destinationPath = @"D:\" + RandomString(255);
+
+            var ex = Assert.Throws<ArgumentNullException>(() =>
+            {
+                PortingAssistantUtils.CopyDirectory(solutionPath, destinationPath);
+            });
+            Assert.AreEqual(ex.ParamName, nameof(solutionPath));
+        }
+
+        [Test]
+        public void TestEmptyDestinationPathWillThrowException()
+        {
+            var solutionPath = "cs/yy.sln";
+            var destinationPath = "";
+
+            var ex = Assert.Throws<ArgumentNullException>(() =>
+            {
+                PortingAssistantUtils.CopyDirectory(solutionPath, destinationPath);
+            });
+            Assert.AreEqual(ex.ParamName, nameof(destinationPath));
         }
 
         private static string RandomString(int length)

--- a/packages/csharp/PortingAssistant/PortingAssistant.UnitTests/PortingAssistantUtilsTests.cs
+++ b/packages/csharp/PortingAssistant/PortingAssistant.UnitTests/PortingAssistantUtilsTests.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using NUnit.Framework;
 using PortingAssistant.Common.Utils;
 
@@ -21,15 +19,12 @@ namespace PortingAssistant.UnitTests
         {
             var solutionPath = RandomString(265);
             var destinationPath = "xx/yy.sln";
-            try
+           
+            var ex = Assert.Throws<PathTooLongException>(() =>
             {
                 PortingAssistantUtils.CopyDirectory(solutionPath, destinationPath);
-            }
-            catch (Exception e)
-            {
-                Assert.AreEqual(e.Message,
-                    $"The solution path length cannot exceed {MaxPathLength} characters. Please try a location that has a shorter path.");
-            }
+            });
+            Assert.AreEqual(ex.Message, $"The solution path length cannot exceed {MaxPathLength} characters. Please try a location that has a shorter path.");
         }
 
         [Test]
@@ -38,15 +33,25 @@ namespace PortingAssistant.UnitTests
             var solutionPath = "xx/yy.sln";
             var destinationPath = RandomString(258);
 
-            try
+            var ex = Assert.Throws<PathTooLongException>(() =>
             {
                 PortingAssistantUtils.CopyDirectory(solutionPath, destinationPath);
-            }
-            catch (Exception e)
+            });
+            Assert.AreEqual(ex.Message, $"The destination path length cannot exceed {MaxPathLength} characters. Please try a location that has a shorter path.");
+        }
+
+        [Test]
+        public void TestFileNamePlusDestinationPathEqualToMaxWillNotThrowPathTooLongException()
+        {
+            var solutionPath = "xx/yy.sln";
+            var destinationPath = RandomString(254);
+            
+            // since 'xx/yy.sln' is a fake path, in the end this directory will not be found,
+            // but throws this exception means our checks for path too long has been passed
+            var ex = Assert.Throws<DirectoryNotFoundException>(() =>
             {
-                Assert.AreEqual(e.Message,
-                    $"The destination path length cannot exceed {MaxPathLength} characters. Please try a location that has a shorter path.");
-            }
+                PortingAssistantUtils.CopyDirectory(solutionPath, destinationPath);
+            });
         }
 
         private static string RandomString(int length)

--- a/packages/csharp/PortingAssistant/PortingAssistant.UnitTests/PortingAssistantUtilsTests.cs
+++ b/packages/csharp/PortingAssistant/PortingAssistant.UnitTests/PortingAssistantUtilsTests.cs
@@ -13,45 +13,30 @@ namespace PortingAssistant.UnitTests
         private static Random random = new Random();
         private const int MaxPathLength = 260;
 
-
         [Test]
-        public void TestSolutionPathTooLongWillThrowException()
+        public void TestLongestFileNamePlusDestinationPathTooLongWillThrowException()
         {
-            var solutionPath = RandomString(265);
-            var destinationPath = "xx/yy.sln";
-           
-            var ex = Assert.Throws<PathTooLongException>(() =>
-            {
-                PortingAssistantUtils.CopyDirectory(solutionPath, destinationPath);
-            });
-            Assert.AreEqual(ex.Message, $"The solution path length cannot exceed {MaxPathLength} characters. Please try a location that has a shorter path.");
-        }
-
-        [Test]
-        public void TestFileNamePlusDestinationPathTooLongWillThrowException()
-        {
-            var solutionPath = "xx/yy.sln";
-            var destinationPath = RandomString(258);
+            var solutionPath = "cs/yy.sln";
+            var destinationPath = @"D:\" + RandomString(258);
 
             var ex = Assert.Throws<PathTooLongException>(() =>
             {
                 PortingAssistantUtils.CopyDirectory(solutionPath, destinationPath);
             });
-            Assert.AreEqual(ex.Message, $"The destination path length cannot exceed {MaxPathLength} characters. Please try a location that has a shorter path.");
+            Assert.AreEqual(ex.Message, $"The destination path length cannot exceed {MaxPathLength - 1} characters. Please try a location that has a shorter path.");
         }
 
         [Test]
-        public void TestFileNamePlusDestinationPathEqualToMaxWillNotThrowPathTooLongException()
+        public void TestLongestFileNamePlusDestinationPathEqualToMaxWillThrowPathTooLongException()
         {
-            var solutionPath = "xx/yy.sln";
-            var destinationPath = RandomString(254);
-            
-            // since 'xx/yy.sln' is a fake path, in the end this directory will not be found,
-            // but throws this exception means our checks for path too long has been passed
-            var ex = Assert.Throws<DirectoryNotFoundException>(() =>
+            var solutionPath = "cs/yy.sln";
+            var destinationPath = @"D:\" + RandomString(255);
+
+            var ex = Assert.Throws<PathTooLongException>(() =>
             {
                 PortingAssistantUtils.CopyDirectory(solutionPath, destinationPath);
             });
+            Assert.AreEqual(ex.Message, $"The destination path length cannot exceed {MaxPathLength - 1} characters. Please try a location that has a shorter path.");
         }
 
         private static string RandomString(int length)

--- a/packages/csharp/PortingAssistant/PortingAssistant.UnitTests/PortingAssistantUtilsTests.cs
+++ b/packages/csharp/PortingAssistant/PortingAssistant.UnitTests/PortingAssistantUtilsTests.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using PortingAssistant.Common.Utils;
+
+
+namespace PortingAssistant.UnitTests
+{
+
+    public class PortingAssistantUtilsTests
+    {
+        private static Random random = new Random();
+
+        [Test]
+        public void TestSolutionPathTooLongWillThrowException()
+        {
+            var solutionPath = RandomString(280);
+            var destinationPath = "xx";
+            try
+            {
+                PortingAssistantUtils.CopyDirectory(solutionPath, destinationPath);
+            }
+            catch (Exception e)
+            {
+                Assert.AreEqual(e.Message,
+                    "The solution path length cannot exceed 260 characters. Please try a location that has a shorter path.");
+            }
+        }
+
+        [Test]
+        public void TestDestinationPathTooLongWillThrowException()
+        {
+            var solutionPath = "xx";
+            var destinationPath = RandomString(280);
+            try
+            {
+                PortingAssistantUtils.CopyDirectory(solutionPath, destinationPath);
+            }
+            catch (Exception e)
+            {
+                Assert.AreEqual(e.Message,
+                    "The destination path length cannot exceed 260 characters. Please try a location that has a shorter path.");
+            }
+        }
+
+        private static string RandomString(int length)
+        {
+            const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+            return new string(Enumerable.Repeat(chars, length)
+                .Select(s => s[random.Next(s.Length)]).ToArray());
+        }
+    }
+}

--- a/packages/csharp/PortingAssistant/PortingAssistant.UnitTests/PortingAssistantUtilsTests.cs
+++ b/packages/csharp/PortingAssistant/PortingAssistant.UnitTests/PortingAssistantUtilsTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
-using Microsoft.CodeAnalysis;
 using NUnit.Framework;
 using PortingAssistant.Common.Utils;
 

--- a/packages/react/src/components/PortConfigurationModal/PortConfigurationModal.tsx
+++ b/packages/react/src/components/PortConfigurationModal/PortConfigurationModal.tsx
@@ -29,8 +29,9 @@ const PortConfigurationModalInternal: React.FC<Props> = ({ solution, visible, on
         type: data.portingLocation.value,
         workingDirectory: data.path
       };
-      if (portingLocation.workingDirectory.length > 260){
-        setError("path", "error", "The path length cannot exceed 260 characters. Please try a location that has a shorter path.");
+      const MaxPathLength = 260;
+      if (portingLocation.workingDirectory.length > MaxPathLength){
+        setError("path", "error", `The path length cannot exceed ${MaxPathLength} characters. Please try a location that has a shorter path.`);
         return false;
       }
       if (isLoaded(solution)) {

--- a/packages/react/src/components/PortConfigurationModal/PortConfigurationModal.tsx
+++ b/packages/react/src/components/PortConfigurationModal/PortConfigurationModal.tsx
@@ -29,6 +29,10 @@ const PortConfigurationModalInternal: React.FC<Props> = ({ solution, visible, on
         type: data.portingLocation.value,
         workingDirectory: data.path
       };
+      if (portingLocation.workingDirectory.length > 260){
+        setError("path", "error", "The path length cannot exceed 260 characters. Please try a location that has a shorter path.");
+        return false;
+      }
       if (isLoaded(solution)) {
         switch (portingLocation.type) {
           case "copy":


### PR DESCRIPTION
*Issue #, if available:*
V731980280

*Description of changes:*
- Added path too long check in both react and C#. 
1. Frontend: added path too long check 
2. C#: added path too long check for solutionPath and destinationPath
3. C#: added unit tests for solutionPath and destinationPath

*Testing done:*
- Added unit tests for C#.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including READMEs and comments (where appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific environment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.