### PR TITLE
Add path too long integration test

### DIFF
--- a/packages/csharp/PortingAssistant/PortingAssistant.Api/Application.cs
+++ b/packages/csharp/PortingAssistant/PortingAssistant.Api/Application.cs
@@ -70,16 +70,24 @@ namespace PortingAssistant.Api
             });
 
 
-            _connection.On<CopyDirectoryRequest>("copyDirectory", request =>
+            _connection.On<CopyDirectoryRequest, Response<bool, string>>("copyDirectory", request =>
              {
                  try
                  {
-                     PortingAssistantUtils.CopyDirectory(request.solutionPath, request.destinationPath);
+                    PortingAssistantUtils.CopyDirectory(request.solutionPath, request.destinationPath);
+                    return new Response<bool, string>
+                    {
+                        Status = Response<bool, string>.Success()
+                    };
                  }
                  catch (Exception ex)
                  {
-                     _logger.LogError(ex, "Failed to copy the solution to new location");
-                     throw;
+                    _logger.LogError(ex, "Failed to copy the solution to new location");
+                    return new Response<bool, string>
+                    {
+                        Status = Response<bool, string>.Failed(ex),
+                        ErrorValue = ex.Message
+                    };
                  }
 
              });

--- a/packages/integration-test/src/testRunner.ts
+++ b/packages/integration-test/src/testRunner.ts
@@ -214,7 +214,9 @@ export class TestRunner {
     } else if (selectLocation == "copy") {
       await (await this.app.client.$("#select-location-button")).click();
       await (await this.app.client.$(`div[data-value="copy"]`)).click();
-      await (await this.app.client.$(`icon="folder-open"`)).click();
+      await this.app.client.pause(1000);
+      
+      await (await this.app.client.$("#folder-open-button")).click();
       await (await this.app.client.$("#save-button")).click();
       await this.app.client.pause(3000);
       await (

--- a/packages/react/src/bootstrapElectron.ts
+++ b/packages/react/src/bootstrapElectron.ts
@@ -77,7 +77,7 @@ export interface Backend {
 }
 
 export interface Porting {
-  copyDirectory: (solutionPath: string, destinationPath: string) => void;
+  copyDirectory: (solutionPath: string, destinationPath: string) => Promise<Response<boolean, string>>;
   getConfig: () => SolutionToPortingProjects;
   setConfig: (data: SolutionToPortingProjects) => void;
   applyPortingProjectFileChanges: (

--- a/packages/react/src/components/PortConfigurationModal/LocationSection.tsx
+++ b/packages/react/src/components/PortConfigurationModal/LocationSection.tsx
@@ -1,4 +1,5 @@
 import { Box, Button, ColumnLayout, FormField, Select, SelectProps } from "@awsui/components-react";
+import process from "process";
 import React, { useMemo } from "react";
 import { Controller, FormContextValues } from "react-hook-form";
 import { useLocation } from "react-router";
@@ -30,7 +31,7 @@ const LocationSectionInternal: React.FC<Props> = ({ control, errors, watch, setV
                 description="Porting Assistant for .NET will copy your solution to the selected location."
                 errorText={errorText}
               >
-                <Button iconName="folder-open" onClick={openDialog(onChange)} formAction="none" disabled={isSubmitting}>
+                <Button id="folder-open-button" iconName="folder-open" onClick={openDialog(onChange)} formAction="none" disabled={isSubmitting}>
                   Choose folder
                 </Button>
               </FormField>
@@ -113,8 +114,13 @@ const LocationSectionInternal: React.FC<Props> = ({ control, errors, watch, setV
   );
 };
 
-const openDialog = (onChange: (value: string | undefined) => void) => () =>
-  window.electron.dialog
+const openDialog = (onChange: (value: string | undefined) => void) => ()=> {
+  // for intgration test, add a path which is >250 length which will trigged path too long error due to fileName + path > 260
+  if (process.env["NODE_ENV"] === "test"){
+    onChange("D:\\Users\\qwertyuiopsdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklcvbnmqwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnmqwertyuiopasdfssbnmqwertyutyurtyuioprtyuio");
+  }
+  else{
+    window.electron.dialog
     .showOpenDialog({
       properties: ["openDirectory"]
     })
@@ -125,6 +131,8 @@ const openDialog = (onChange: (value: string | undefined) => void) => () =>
     .catch(err => {
       logError("LocationSection.tsx", "Unable to open directory", err);
     });
+  }
+  }
 
 function is_directory_outside_sln_path(path: string, solutionFilePath: string, solutionName: string) {
     // we need to consider the .sln extension while getting the substring for the solution path

--- a/packages/react/src/components/PortConfigurationModal/PortConfigurationModal.tsx
+++ b/packages/react/src/components/PortConfigurationModal/PortConfigurationModal.tsx
@@ -2,9 +2,11 @@ import { Box, Button, Modal, Spinner } from "@awsui/components-react";
 import React, { useMemo } from "react";
 import { useForm } from "react-hook-form";
 import { useDispatch } from "react-redux";
+import { v4 as uuid } from "uuid";
 
 import { PortingLocation } from "../../models/porting";
 import { SolutionDetails } from "../../models/solution";
+import { pushCurrentMessageUpdate } from "../../store/actions/error";
 import { setPortingLocation } from "../../store/actions/porting";
 import { isLoaded, Loadable } from "../../utils/Loadable";
 import { LocationSection } from "./LocationSection";
@@ -31,19 +33,25 @@ const PortConfigurationModalInternal: React.FC<Props> = ({ solution, visible, on
       };
       const MaxPathLength = 260;
       if (portingLocation.workingDirectory.length > MaxPathLength){
-        setError("path", "error", `The path length cannot exceed ${MaxPathLength} characters. Please try a location that has a shorter path.`);
+        setError("path", "error", `The path length cannot exceed ${MaxPathLength - 1} characters. Please try a location that has a shorter path.`);
         return false;
       }
       if (isLoaded(solution)) {
-        switch (portingLocation.type) {
-          case "copy":
-            try {
-                await window.porting.copyDirectory(solution.data.solutionFilePath, portingLocation.workingDirectory);
-            } catch (err) {
-              setError("path", "error", `Unable to copy solution to directory. Error: ${err}`);
-              return false;
-            }
-            break;
+        if(portingLocation.type == "copy"){
+          const response = await window.porting.copyDirectory(solution.data.solutionFilePath, portingLocation.workingDirectory);
+          if (response.status.status === "Failure"){
+            setError("path", "error", `Unable to copy solution to directory. Error: ${response.errorValue}`);
+            dispatch(
+              pushCurrentMessageUpdate({
+                  messageId: uuid(),
+                  groupId: "path-too-long",
+                  type: "error",
+                  content: response.errorValue,
+                  dismissible: true,
+              })
+            );
+            return false;
+          }
         }
         dispatch(setPortingLocation({ solutionPath: solution.data.solutionFilePath, portingLocation }));
       }


### PR DESCRIPTION
*Issue #, if available:*
Follow up for this https://github.com/aws/porting-assistant-dotnet-ui/pull/620 
To add proper alerting message in UI for path too long and integration test for this case

*Description of changes:*
![Screen Shot 2022-11-02 at 8 06 57 PM](https://user-images.githubusercontent.com/115844756/199890506-97d91fe5-f8ce-4c1b-bb0a-9928fbfccac4.png)
1. C# - CopyDirectory will return <Boolean, String> where String will be error message when exception happened
2. Add error flash bar in UI for the case FilePath + Destination Path > 260, see screen shot above
3. (TO DO) add integration test for passing a long destination path with length (250, 260), which will trigged error flash bar
- Question: (process.env["NODE_ENV"] === "test") is not working as expected when running Canary.Spec.ts.
- Question: Cannot find log for any debugging LogError

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including READMEs and comments (where appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific environment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.